### PR TITLE
SPS-14: Replicate the GUI in WPF

### DIFF
--- a/C_Flat_GUI/MainWindow.xaml
+++ b/C_Flat_GUI/MainWindow.xaml
@@ -6,7 +6,39 @@
         xmlns:local="clr-namespace:C_Flat"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
-    <Grid>
+    <Grid Margin="10">
+        
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        
+        <Label>C__Flat source input</Label>
+        <TextBox Grid.Row="1" Margin="0,10,0,10"
+                 Name="SourceInput"
+                 TextWrapping="NoWrap"
+                 AcceptsReturn="True"
+                 AcceptsTab="True"
+                 VerticalScrollBarVisibility="Visible"
+        />
+        
+        <Button Grid.Row="2" x:Name="btnInterpret" Margin="0,0,0,0" Click="ButtonInterpret_Click">Interpret Code</Button>
+        
+        <Label Grid.Row="3">C__Flat interpreter output</Label>
+        <TextBox Grid.Row="4" Margin="0,10,0,0"
+                 Name="Output"
+                 TextWrapping="NoWrap"
+                 VerticalScrollBarVisibility="Visible"
+                 IsReadOnly="True"
+        />
 
     </Grid>
 </Window>

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -24,5 +24,12 @@ namespace C_Flat
         {
             InitializeComponent();
         }
+        
+        private void ButtonInterpret_Click(object sender, RoutedEventArgs e)
+        {
+            Output.Text = SourceInput.Text;
+            var test = SourceInput.Text.ToCharArray();
+            SourceInput.Clear();
+        }
     }
 }


### PR DESCRIPTION
## Changes:
- Added a simple user interface with a text box for entering C_Flat and a text box which shows the interpreted output. It also has a button which currently just moves the text from the input to the output. 
![image](https://user-images.githubusercontent.com/57400783/196915443-99a1915a-b46b-4969-831e-f7fbf69db833.png)

## Considerations:
- I need to look into how testing is conducted for WPF forms and whether it is worth testing something as rudimentary as the GUI.  Though this will be done in a follow-up PR/ticket.