### PR TITLE
Add logging to C_Flat

### DIFF
--- a/C_Flat_Interpreter/C_Flat_Interpreter.csproj
+++ b/C_Flat_Interpreter/C_Flat_Interpreter.csproj
@@ -10,4 +10,9 @@
       <Folder Include="Common" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0-rc.2.22472.3" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0-rc.2.22472.3" />
+    </ItemGroup>
+
 </Project>

--- a/C_Flat_Interpreter/Common/InterpreterLogger.cs
+++ b/C_Flat_Interpreter/Common/InterpreterLogger.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace C_Flat_Interpreter.Common;
+
+public abstract class InterpreterLogger
+{
+    public ILogger GetLogger(string category)
+    {
+        using ILoggerFactory loggerFactory =
+            LoggerFactory.Create(builder =>
+                builder.AddSimpleConsole());
+        return loggerFactory.CreateLogger(category);
+    }
+}

--- a/C_Flat_Tests/C_Flat_Tests.csproj
+++ b/C_Flat_Tests/C_Flat_Tests.csproj
@@ -9,6 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0-rc.2.22472.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0-rc.2.22472.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/C_Flat_Tests/Common/TestLogger.cs
+++ b/C_Flat_Tests/Common/TestLogger.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace C_Flat_Tests.Common;
+
+public class TestLogger
+{
+    public ILogger GetLogger(string category)
+    {
+        using ILoggerFactory loggerFactory =
+            LoggerFactory.Create(builder =>
+                builder.AddSimpleConsole());
+        return loggerFactory.CreateLogger(category);
+    }
+}


### PR DESCRIPTION
## Changes:
- `Microsoft.Extensions.Logging` NuGet package added
- `Microsoft.Extensions.Logging.Console` NuGet package added
- `InterpreterLogger.cs` abstract class added to enable better logging for interpreter classes
- `testLogger.cs` abstract class added to enable better logging for test classes
## Considerations:
- Due to the logger classes being abstract, to enable use of loggers in new classes. You should inherit from the appropriate abstract logger class (e.g. `TestLogger` for test classes). Then within the constructor of the new class use the `GetLogger` method to retrieve a logger for that class.
- The `GetLogger` method takes a string argument which will be used to set the category for that logger. Logger categories are appended at the start of each log message. E.g. a logger for the class "Lexer" could have the category "Lexer Class".