### PR TITLE
Transpile variables and UI refactor

### DIFF
--- a/C_Flat_CLI/CLIProgram.cs
+++ b/C_Flat_CLI/CLIProgram.cs
@@ -24,7 +24,7 @@ internal static class CLIProgram
             return;
         }
         Transpiler _transpiler = new Transpiler();
-        _transpiler.Transpile(_lexer.GetTokens());
+        _transpiler.Transpile(_parser.GetParseTree());
         Console.WriteLine($"Successfully transpiled output to {_transpiler.GetProgramPath()}");
     }
 }

--- a/C_Flat_GUI/MainWindow.xaml
+++ b/C_Flat_GUI/MainWindow.xaml
@@ -40,7 +40,6 @@
                                 <Grid.RowDefinitions>
                                         <RowDefinition Height="*" />
                                         <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
                                 <ui:Card Grid.Row="0" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch" Background="#38006b">
                                         <Grid>
@@ -67,59 +66,40 @@
                                         </Grid>
                                 </ui:Card>
                                 <ui:Card Grid.Row="1" VerticalAlignment="Center" Margin="0,10" Background="Transparent" Padding="10,10" BorderThickness="0">
-                                        <Grid>
-                                                <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*" />
-                                                        <ColumnDefinition Width="*" />
-                                                </Grid.ColumnDefinitions> 
-                                                <ui:Button Grid.Column="0" Click="ButtonTranspile_Click" Margin="5" HorizontalAlignment="Center" Background="#C86A1B9A">Transpile Code</ui:Button>
-                                                <ui:Button Grid.Column="1" Click="ButtonTranspileAndRun_Click" Margin="5" HorizontalAlignment="Center" Background="#C86A1B9A">Run Transpiled Code</ui:Button>
-                                        </Grid>
-                                </ui:Card>
-                                <ui:Card Grid.Row="2" VerticalAlignment="Stretch" Background="#38006b" VerticalContentAlignment="Stretch">
-                                        <Grid VerticalAlignment="Stretch">
-                                                <Grid.RowDefinitions>
-                                                        <RowDefinition Height="Auto" />
-                                                        <RowDefinition Height="*" />
-                                                </Grid.RowDefinitions>
-                                                <Label HorizontalAlignment="Center" Foreground="#C8FFFFFF">Transpiler Output</Label>
-                                                <Grid Grid.Row="1" VerticalAlignment="Stretch">
-                                                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" VerticalAlignment="Stretch">
-                                                                <Border CornerRadius="3" Background="#2CFFFFFF" Padding="5">
-                                                                        <TextBlock
-                                                                        Background="Transparent"
-                                                                        Foreground="White"
-                                                                        Name="TranspilerOutput"
-                                                                        VerticalAlignment="Stretch"
-                                                                        TextWrapping="NoWrap"/>
-                                                                </Border>
-                                                        </ScrollViewer>
-                                                </Grid>
-                                               
-                                        </Grid>
+                                        <ui:Button Click="ButtonTranspile_Click" Margin="5" HorizontalAlignment="Stretch" Background="#C86A1B9A">Transpile Source Input</ui:Button>
                                 </ui:Card>
                         </Grid>
-                        <ui:Card Grid.Column="1" Margin="5,5,5,0" Background="#38006b" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
+                        <Grid Grid.Column="1" Margin="5, 5, 5, 0">
+                                <Grid.RowDefinitions>
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <ui:Card Background="#38006b" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
                                 <Grid>
                                         <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto" />
                                                 <RowDefinition Height="*" />
                                         </Grid.RowDefinitions>
-                                        <Label HorizontalAlignment="Center" Foreground="#C8FFFFFF">Transpiled Code execution output</Label>
+                                        <Label HorizontalAlignment="Center" Foreground="#C8FFFFFF">Transpiler Output</Label>
                                         <Grid Grid.Row="1" VerticalAlignment="Stretch">
                                                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" VerticalAlignment="Stretch">
-                                                        <Border CornerRadius="3" Background="#2CFFFFFF" Padding="5">
+                                                        <Border Name="OutputBorder" CornerRadius="3" Background="#2CFFFFFF" Padding="5" BorderBrush="#2CFFFFFF" BorderThickness="2">
                                                                 <TextBlock
                                                                         Background="Transparent"
                                                                         Foreground="White" 
-                                                                        Name="ExecutionOutput"
+                                                                        Name="OutputBlock"
                                                                         VerticalAlignment="Stretch"
-                                                                        TextWrapping="NoWrap"/>  
+                                                                        TextWrapping="NoWrap"
+                                                                        />  
                                                         </Border>
                                                 </ScrollViewer>
                                         </Grid>
                                 </Grid>
                         </ui:Card>
+                                <ui:Card Grid.Row="1" VerticalAlignment="Center" Margin="0,10" Background="Transparent" Padding="10,10" BorderThickness="0">
+                                        <ui:Button Click="ButtonExecuteCode_Click" Name="ExecuteButton" Margin="5" IsEnabled="False" Visibility="Visible" HorizontalAlignment="Stretch" Background="#C86A1B9A">Execute Transpiled Code</ui:Button>
+                                </ui:Card>
+                        </Grid>
                 </Grid>
         </Grid>
 </ui:UiWindow>

--- a/C_Flat_GUI/MainWindow.xaml
+++ b/C_Flat_GUI/MainWindow.xaml
@@ -65,9 +65,19 @@
                                                 </Grid>
                                         </Grid>
                                 </ui:Card>
-                                <ui:Card Grid.Row="1" VerticalAlignment="Center" Margin="0,10" Background="Transparent" Padding="10,10" BorderThickness="0">
-                                        <ui:Button Click="ButtonTranspile_Click" Margin="5" HorizontalAlignment="Stretch" Background="#C86A1B9A">Transpile Source Input</ui:Button>
-                                </ui:Card>
+                                
+                                <Grid Grid.Row="1" Margin="0,10">
+                                        <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <ui:Card Grid.Column="0" VerticalAlignment="Center" Background="Transparent" Padding="10,10" BorderThickness="0">
+                                                <ui:Button Click="ButtonTranspile_Click" Name="TranspileButton" Margin="5" HorizontalAlignment="Stretch" Background="#C86A1B9A">Transpile Source Input</ui:Button>
+                                        </ui:Card>
+                                        <ui:Card Grid.Column="1" VerticalAlignment="Center" Background="Transparent" Padding="2,10" BorderThickness="0">
+                                                <ui:Button Click="ButtonExecuteCode_Click" Name="ExecuteButton" Margin="5" IsEnabled="False" Visibility="Visible" HorizontalAlignment="Stretch" Background="#C86A1B9A">Execute Transpiled Code</ui:Button>
+                                        </ui:Card>
+                                </Grid>
                         </Grid>
                         <Grid Grid.Column="1" Margin="5, 5, 5, 0">
                                 <Grid.RowDefinitions>
@@ -75,30 +85,40 @@
                                         <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
                                 <ui:Card Background="#38006b" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
-                                <Grid>
-                                        <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="*" />
-                                        </Grid.RowDefinitions>
-                                        <Label HorizontalAlignment="Center" Foreground="#C8FFFFFF">Transpiler Output</Label>
-                                        <Grid Grid.Row="1" VerticalAlignment="Stretch">
-                                                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" VerticalAlignment="Stretch">
-                                                        <Border Name="OutputBorder" CornerRadius="3" Background="#2CFFFFFF" Padding="5" BorderBrush="#2CFFFFFF" BorderThickness="2">
-                                                                <TextBlock
-                                                                        Background="Transparent"
-                                                                        Foreground="White" 
-                                                                        Name="OutputBlock"
-                                                                        VerticalAlignment="Stretch"
-                                                                        TextWrapping="NoWrap"
-                                                                        />  
-                                                        </Border>
-                                                </ScrollViewer>
+                                        <Grid Name="TestGrid">
+                                                <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto" />
+                                                        <RowDefinition Height="*" />
+                                                </Grid.RowDefinitions>
+                                                <Label HorizontalAlignment="Center" Foreground="#C8FFFFFF">Transpiler Output</Label>
+                                                <Grid Grid.Row="1" VerticalAlignment="Stretch">
+                                                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" VerticalAlignment="Stretch">
+                                                                <Border Name="OutputBorder" CornerRadius="3" Background="#2CFFFFFF" Padding="5" BorderBrush="#2CFFFFFF" BorderThickness="2">
+                                                                        <TextBlock
+                                                                                Background="Transparent"
+                                                                                Foreground="White"
+                                                                                VerticalAlignment="Stretch"
+                                                                                TextWrapping="NoWrap"
+                                                                                IsEnabled="False"
+                                                                                />  
+                                                                </Border>
+                                                        </ScrollViewer>
+                                                </Grid>
                                         </Grid>
-                                </Grid>
-                        </ui:Card>
-                                <ui:Card Grid.Row="1" VerticalAlignment="Center" Margin="0,10" Background="Transparent" Padding="10,10" BorderThickness="0">
-                                        <ui:Button Click="ButtonExecuteCode_Click" Name="ExecuteButton" Margin="5" IsEnabled="False" Visibility="Visible" HorizontalAlignment="Stretch" Background="#C86A1B9A">Execute Transpiled Code</ui:Button>
                                 </ui:Card>
+                                <Grid Grid.Row="1" Margin="0,10">
+                                        <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <ui:Card Grid.Column="0" Name="LeftButton" VerticalAlignment="Center" Background="Transparent" Padding="2,10" BorderThickness="0">
+                                                <ui:Button Name="test" Margin="5" HorizontalAlignment="Stretch" Background="#C86A1B9A">Transpile Source Input</ui:Button>
+                                        </ui:Card>
+                                        <ui:Card Grid.Column="1" Name="RightButton" VerticalAlignment="Center" Background="Transparent" Padding="2,10" BorderThickness="0">
+                                                <ui:Button  Name="anotherTest" Margin="5" HorizontalAlignment="Stretch" Background="#C86A1B9A">Transpile Source Input</ui:Button>
+                                        </ui:Card>
+                                </Grid>
+                                
                         </Grid>
                 </Grid>
         </Grid>

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -4,16 +4,21 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
 using C_Flat_Interpreter.Lexer;
 using C_Flat_Interpreter.Parser;
 using C_Flat_Interpreter.Transpiler;
 using Microsoft.Win32;
 using Serilog.Events;
 using Wpf.Ui.Controls;
+using Button = Wpf.Ui.Controls.Button;
 using MessageBox = System.Windows.MessageBox;
+using TreeViewItem = System.Windows.Controls.TreeViewItem;
+
 namespace C_Flat
 {
     /// <summary>
@@ -24,36 +29,97 @@ namespace C_Flat
         private readonly Lexer _lexer;
         private readonly Parser _parser;
         private readonly Transpiler _transpiler;
-        
         private bool _programChanged;
+        private LinearGradientBrush _executionBrush;
+        private Storyboard _executionAnim;
+
+        private TreeView? _parseTree;
+        private Button _ShowTree;
+        private TextBlock _CodeView;
+        private Button _ShowCode;
+        private TextBlock? _ExecutionOutput;
+        private Button _ShowOutput;
+
         public MainWindow()
         {
             InitializeComponent();
             _lexer = new();
             _parser = new();
             _transpiler = new();
+            CreateExecuteAnimation();
+
+            ExecuteButton.IsEnabled = false;
+            
+            _ShowTree = new Button()
+            {
+                Content = "Show parse tree",
+                Margin = new Thickness(5),
+                IsEnabled = false,
+                Visibility = Visibility.Visible,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Background = new SolidColorBrush(Color.FromRgb(106, 27, 154)),
+            };
+            _ShowTree.Click += ShowTree_Click;
+            
+            _ShowOutput = new Button()
+            {
+                Content = "Show execution output",
+                Margin = new Thickness(5),
+                IsEnabled = false,
+                Visibility = Visibility.Visible,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Background = new SolidColorBrush(Color.FromRgb(106, 27, 154)),
+            };
+            _ShowOutput.Click += ShowOutput_Click;
+            
+            _ShowCode = new Button()
+            {
+                Content = "Show transpiled code",
+                Margin = new Thickness(5),
+                IsEnabled = true,
+                Visibility = Visibility.Visible,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Background = new SolidColorBrush(Color.FromRgb(106, 27, 154)),
+            };
+            _ShowCode.Click += ShowCode_Click;
+            
+            LeftButton.Content = _ShowTree;
+            RightButton.Content = _ShowOutput;
+
+            _CodeView = new TextBlock()
+            {
+                Background = Brushes.Transparent,
+                Foreground = Brushes.White,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                TextWrapping = TextWrapping.NoWrap,
+                IsEnabled = false,
+            };
+            OutputBorder.Child = _CodeView;
         }
 
         private void ButtonTranspile_Click(object sender, RoutedEventArgs e)
         {
-            OutputBlock.Text = "";
+            _CodeView.Text = "";
             SourceInput.BorderThickness = new Thickness(0);
             OutputBorder.BorderThickness = new Thickness(0);
-
+            ExecuteButton.IsEnabled = false;
+            _ExecutionOutput = null;
+            _parseTree = null;
             _programChanged = true;
             _lexer.ClearLogs();
             if (_lexer.Tokenise(SourceInput.Text) != 0)
             {
                 //Lexer Failed!
-                OutputBlock.Inlines.Clear();
+                _CodeView.Inlines.Clear();
                 var run = new Run
                 {
                     Text = "Parsing Failed! Printing logs: \n",
                     Background = Brushes.DarkRed,
                     Foreground = Brushes.White
                 };
-                OutputBlock.Inlines.Add(new Bold(run));
-                foreach (var errorMessage in _parser.GetInMemoryLogs().Where(log => log.Level > LogEventLevel.Information))
+                _CodeView.Inlines.Add(new Bold(run));
+                foreach (var errorMessage in _parser.GetInMemoryLogs()
+                             .Where(log => log.Level > LogEventLevel.Information))
                 {
                     run.Background = errorMessage.Level switch
                     {
@@ -61,61 +127,86 @@ namespace C_Flat
                         _ => Brushes.DarkRed
                     };
                     run.Text = errorMessage.RenderMessage();
-                    OutputBlock.Inlines.Add(run);
+                    _CodeView.Inlines.Add(run);
                 }
                 SourceInput.BorderBrush = new SolidColorBrush(Colors.DarkRed);
                 SourceInput.BorderThickness = new Thickness(2);
-                ExecuteButton.IsEnabled = false;
+                _ShowTree.IsEnabled = false;
                 return;
             }
+
             var tokens = _lexer.GetTokens();
             _parser.ClearLogs();
+            
             if (_parser.Parse(tokens) != 0)
             {
                 //Parser failed!
-                OutputBlock.Inlines.Clear();
+                _CodeView.Inlines.Clear();
                 var run = new Run
                 {
                     Text = "Parsing Failed! Printing logs: \n",
                     Background = Brushes.DarkRed,
                     Foreground = Brushes.White
                 };
-                OutputBlock.Inlines.Add(new Bold(run));
-                foreach (var errorMessage in _parser.GetInMemoryLogs().Where(log => log.Level > LogEventLevel.Information))
+                _CodeView.Inlines.Add(new Bold(run));
+                foreach (var errorMessage in _parser.GetInMemoryLogs()
+                             .Where(log => log.Level > LogEventLevel.Information))
                 {
                     run.Background = errorMessage.Level switch
                     {
                         LogEventLevel.Warning => new SolidColorBrush(Colors.Goldenrod),
                         _ => Brushes.DarkRed
                     };
-                    run.Text = errorMessage.RenderMessage();
-                    OutputBlock.Inlines.Add(run);
+                    run.Text = errorMessage.RenderMessage() + "\n";
+                    _CodeView.Inlines.Add(run);
                 }
+                
                 SourceInput.BorderBrush = new SolidColorBrush(Colors.DarkRed);
                 SourceInput.BorderThickness = new Thickness(2);
-                ExecuteButton.IsEnabled = false;
+                _ShowTree.IsEnabled = false;
                 return;
             }
+
+            //Construct parse tree element passing parse tree
+            ConstructParseTree();
             var transpiledProgram = _transpiler.Transpile(tokens);
             SourceInput.BorderBrush = new SolidColorBrush(Colors.LawnGreen);
             SourceInput.BorderThickness = new Thickness(2);
             ExecuteButton.IsEnabled = true;
-            OutputBlock.Text = $"{transpiledProgram}";
+            _CodeView.Text = $"{transpiledProgram}";
+            ShowCode_Click(default, default);
         }
-        
+
         private async void ButtonExecuteCode_Click(object sender, RoutedEventArgs e)
         {
+            
+            TranspileButton.IsEnabled = false;
+            ExecuteButton.IsEnabled = false;
+            _ExecutionOutput = new TextBlock
+            {
+                Background = Brushes.Transparent,
+                Foreground = Brushes.White,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                TextWrapping = TextWrapping.NoWrap,
+                IsEnabled = false,
+                Text = "Execution in progress..."
+            };
+            ShowOutput_Click(default, default);
+            //_ShowOutput.IsEnabled = true;
+            //Begin execution textbox animation
             Mouse.OverrideCursor = Cursors.Wait;
-            OutputBlock.Text = "Executing transpiled code!!";
-            OutputBorder.BorderBrush = new SolidColorBrush(Colors.MediumPurple);
-            OutputBorder.BorderThickness = new Thickness(2);
+            OutputBorder.BorderBrush = _executionBrush;
+            OutputBorder.BorderThickness = new Thickness(3);
+            _executionAnim.Begin(this);
+
+            //Create and start dotnet run process
             var proc = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
                     Verb = "runas",
                     FileName = "cmd.exe",
-                    Arguments = "/C "+ "dotnet run Program.cs",
+                    Arguments = "/C " + "dotnet run Program.cs",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     CreateNoWindow = true,
@@ -123,15 +214,153 @@ namespace C_Flat
                 }
             };
             proc.Start();
+
+            //store process output logs
             var output = await proc.StandardOutput.ReadToEndAsync();
             await proc.WaitForExitAsync();
+
+            //End execution animation
+            _executionAnim.Stop(this);
             Mouse.OverrideCursor = Cursors.Arrow;
-            OutputBlock.Text = output;
+
+            //Check for errors and format stored output logs
+            if (proc.ExitCode != 0)
+            {
+                _ExecutionOutput.Inlines.Clear();
+                OutputBorder.BorderBrush = new SolidColorBrush(Colors.DarkRed);
+                OutputBorder.BorderThickness = new Thickness(2);
+                var errorLogs = output.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+                foreach (var error in errorLogs)
+                {
+                    var start = error.IndexOf("Program.cs", 0);
+                    var end = error.LastIndexOf('[');
+                    var trimmedError = error.Substring(start, end - start);
+                    _ExecutionOutput.Inlines.Add(new Run()
+                    {
+                        Text = trimmedError + "\n",
+                        Background = Brushes.DarkRed,
+                    });
+                }
+                ExecuteButton.IsEnabled = false;
+                return;
+            }
+            //Otherwise just copy output directly to text-box and apply a green "success border"
+            _ExecutionOutput.Text = output;
             OutputBorder.BorderBrush = new SolidColorBrush(Colors.LawnGreen);
             OutputBorder.BorderThickness = new Thickness(2);
+            TranspileButton.IsEnabled = true;
+            ExecuteButton.IsEnabled = true;
+        }
+
+        private void ConstructParseTree()
+        {
+            _parseTree = new TreeView()
+            {
+                VerticalAlignment = VerticalAlignment.Stretch,
+                Name = "ParseTree",
+            };
+            //TEST CODE, REPLACE WITH PARSER OUTPUT
+            var testItem = new TreeViewItem()
+            {
+                Header = "Function declaration",
+                Items =
+                {
+                    new TreeViewItem() {Header = "If statement",}
+                }
+            };
+            var testItem2 = new TreeViewItem()
+            {
+                Header = "Variable declaration",
+            };
+            _parseTree.Items.Add(testItem);
+            _parseTree.Items.Add(testItem2);
 
         }
 
+        private async void ShowTree_Click(object sender, RoutedEventArgs e)
+        {
+            _ShowOutput.IsEnabled = _ExecutionOutput != null;
+            LeftButton.Content = _ShowOutput;
+            RightButton.Content = _ShowCode;
+            OutputBorder.Child = _parseTree;
+        }
+
+        private async void ShowOutput_Click(object sender, RoutedEventArgs e)
+        {
+            LeftButton.Content = _ShowCode;
+            RightButton.Content = _ShowTree;
+            OutputBorder.Child = _ExecutionOutput;
+        }
+
+        private async void ShowCode_Click(object sender, RoutedEventArgs e)
+        {
+            _ShowTree.IsEnabled = _parseTree != null;
+            LeftButton.Content = _ShowTree;
+            _ShowOutput.IsEnabled = _ExecutionOutput != null;
+            RightButton.Content = _ShowOutput;
+            OutputBorder.Child = _CodeView;
+        }
+
+        private void CreateExecuteAnimation()
+        {
+            //Create animation for execute
+            _executionBrush = new LinearGradientBrush();
+            
+            // Create gradient stops for the brush.
+            var stop1 = new GradientStop(Colors.Plum, 0.0);
+            var stop2 = new GradientStop(Colors.MediumPurple, 0.5);
+            var stop3 = new GradientStop(Colors.Purple, 1.0);
+            
+            RegisterName("Execute1", stop1);
+            RegisterName("Execute2", stop2);
+            RegisterName("Execute3", stop3);
+            
+            _executionBrush.GradientStops.Add(stop1);
+            _executionBrush.GradientStops.Add(stop2);
+            _executionBrush.GradientStops.Add(stop3);
+
+            var stop1Anim = new ColorAnimation
+            {
+                From = Colors.Plum,
+                To = Colors.MediumPurple,
+                Duration = TimeSpan.FromSeconds(0.5),
+                RepeatBehavior = RepeatBehavior.Forever,
+                AutoReverse = true
+            };
+            Storyboard.SetTargetName(stop1Anim, "Execute1");
+            Storyboard.SetTargetProperty(stop1Anim,
+                new PropertyPath(GradientStop.ColorProperty));
+
+            var stop2Anim = new ColorAnimation
+            {
+                From = Colors.MediumPurple,
+                To = Colors.Purple,
+                Duration = TimeSpan.FromSeconds(1.0),
+                RepeatBehavior = RepeatBehavior.Forever,
+                AutoReverse = true
+            };
+            Storyboard.SetTargetName(stop2Anim, "Execute2");
+            Storyboard.SetTargetProperty(stop2Anim,
+                new PropertyPath(GradientStop.ColorProperty));
+            
+            var stop3Anim = new ColorAnimation
+            {
+                From = Colors.Purple,
+                To = Colors.Plum,
+                Duration = TimeSpan.FromSeconds(1.0),
+                RepeatBehavior = RepeatBehavior.Forever,
+                AutoReverse = true
+            };
+            Storyboard.SetTargetName(stop3Anim, "Execute3");
+            Storyboard.SetTargetProperty(stop3Anim,
+                new PropertyPath(GradientStop.ColorProperty));
+
+            _executionAnim = new Storyboard();
+            _executionAnim.Children.Add(stop1Anim);
+            _executionAnim.Children.Add(stop2Anim);
+            _executionAnim.Children.Add(stop3Anim);
+        }
+        
         private void OnWindowClose(object sender, CancelEventArgs e)
         {
             // If the user has transpiled something ask if they want to save

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -172,7 +172,35 @@ namespace C_Flat
             var parseNodes = _parser.GetParseTree();
             //Construct parse tree element passing parse tree
             ConstructParseTree(parseNodes);
-            var transpiledProgram = _transpiler.Transpile(parseNodes);
+            //TODO - move error printing into helper method
+            if (_transpiler.Transpile(parseNodes) != 0)
+            {
+                //Transpiler failed!
+                _codeView.Inlines.Clear();
+                _codeView.Inlines.Add(new Run
+                {
+                    Text = "Transpilation Failed! Printing logs: \n",
+                    Background = Brushes.DarkRed,
+                    Foreground = Brushes.White
+                });
+                foreach (var errorMessage in _transpiler.GetInMemoryLogs()
+                             .Where(log => log.Level > LogEventLevel.Information))
+                {
+                    _codeView.Inlines.Add(new Run
+                    {
+                        Background = errorMessage.Level switch
+                        {
+                            LogEventLevel.Warning => new SolidColorBrush(Colors.Goldenrod),
+                            _ => Brushes.DarkRed
+                        },
+                        Text = errorMessage.RenderMessage() + "\n"
+                    });
+                }
+                SourceInput.BorderBrush = new SolidColorBrush(Colors.DarkRed);
+                SourceInput.BorderThickness = new Thickness(2);
+                return;
+            }
+            var transpiledProgram = _transpiler.Program;
             SourceInput.BorderBrush = new SolidColorBrush(Colors.LawnGreen);
             SourceInput.BorderThickness = new Thickness(2);
             ExecuteButton.IsEnabled = true;

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using C_Flat_Interpreter.Common;
+using C_Flat_Interpreter.Common.Enums;
 using C_Flat_Interpreter.Lexer;
 using C_Flat_Interpreter.Parser;
 using C_Flat_Interpreter.Transpiler;

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -9,6 +10,7 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
+using C_Flat_Interpreter.Common;
 using C_Flat_Interpreter.Lexer;
 using C_Flat_Interpreter.Parser;
 using C_Flat_Interpreter.Transpiler;
@@ -167,9 +169,10 @@ namespace C_Flat
                 return;
             }
 
+            var parseNodes = _parser.GetParseTree();
             //Construct parse tree element passing parse tree
-            ConstructParseTree();
-            var transpiledProgram = _transpiler.Transpile(tokens);
+            ConstructParseTree(parseNodes);
+            var transpiledProgram = _transpiler.Transpile(parseNodes);
             SourceInput.BorderBrush = new SolidColorBrush(Colors.LawnGreen);
             SourceInput.BorderThickness = new Thickness(2);
             ExecuteButton.IsEnabled = true;
@@ -254,29 +257,42 @@ namespace C_Flat
             ExecuteButton.IsEnabled = true;
         }
 
-        private void ConstructParseTree()
+        private void ConstructParseTree(List<ParseNode> parseNodes)
         {
             _parseTree = new TreeView()
             {
                 VerticalAlignment = VerticalAlignment.Stretch,
                 Name = "ParseTree",
             };
-            //TEST CODE, REPLACE WITH PARSER OUTPUT
-            var testItem = new TreeViewItem()
+            foreach (var node in parseNodes)
             {
-                Header = "Function declaration",
-                Items =
+                var treeItem = new TreeViewItem
                 {
-                    new TreeViewItem() {Header = "If statement",}
+                    Header = node.ToString()
+                };
+                if (node.type is NodeType.Terminal) continue;
+                foreach (var childNode in node.getChildren())
+                {
+                    AddNodeTreeItems(treeItem, childNode);
                 }
-            };
-            var testItem2 = new TreeViewItem()
-            {
-                Header = "Variable declaration",
-            };
-            _parseTree.Items.Add(testItem);
-            _parseTree.Items.Add(testItem2);
+                _parseTree.Items.Add(treeItem);
+            }
+        }
 
+        private void AddNodeTreeItems(TreeViewItem parentTreeItem, ParseNode node)
+        {
+            var treeItem = new TreeViewItem
+            {
+                Header = node.ToString()
+            };
+            if (node.type is not NodeType.Terminal)
+            {
+                foreach (var childNode in node.getChildren())
+                {
+                    AddNodeTreeItems(treeItem, childNode);
+                }
+            }
+            parentTreeItem.Items.Add(treeItem);
         }
 
         private void ShowTree_Click(object sender, RoutedEventArgs e)

--- a/C_Flat_Interpreter/C_Flat_Interpreter.csproj
+++ b/C_Flat_Interpreter/C_Flat_Interpreter.csproj
@@ -7,10 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Folder Include="Common" />
-    </ItemGroup>
-
-    <ItemGroup>
       <PackageReference Include="Serilog" Version="2.12.1-dev-01587" />
       <PackageReference Include="Serilog.Sinks.Console" Version="4.1.1-dev-00896" />
       <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />

--- a/C_Flat_Interpreter/Common/Enums/NodeType.cs
+++ b/C_Flat_Interpreter/Common/Enums/NodeType.cs
@@ -1,4 +1,4 @@
-﻿namespace C_Flat_Interpreter.Common;
+﻿namespace C_Flat_Interpreter.Common.Enums;
 
 public enum NodeType //will be added to
 {

--- a/C_Flat_Interpreter/Common/NodeType.cs
+++ b/C_Flat_Interpreter/Common/NodeType.cs
@@ -1,4 +1,4 @@
-﻿namespace C_Flat_Interpreter.Parser;
+﻿namespace C_Flat_Interpreter.Common;
 
 public enum NodeType //will be added to
 {

--- a/C_Flat_Interpreter/Common/ParseNode.cs
+++ b/C_Flat_Interpreter/Common/ParseNode.cs
@@ -1,4 +1,6 @@
-﻿namespace C_Flat_Interpreter.Common;
+﻿using C_Flat_Interpreter.Common.Enums;
+
+namespace C_Flat_Interpreter.Common;
 
 public class ParseNode
 {

--- a/C_Flat_Interpreter/Common/ParseNode.cs
+++ b/C_Flat_Interpreter/Common/ParseNode.cs
@@ -1,12 +1,10 @@
-﻿using C_Flat_Interpreter.Common;
-
-namespace C_Flat_Interpreter.Parser;
+﻿namespace C_Flat_Interpreter.Common;
 
 public class ParseNode
 {
     private List<ParseNode> childNodes = new();
-    private Token? token;
-    private NodeType type;
+    public Token? token;
+    public NodeType type;
     
 //todo - figure out what constructors are needed
     public ParseNode(NodeType type, Token token)
@@ -24,16 +22,28 @@ public class ParseNode
     {
         childNodes.Add(child);
     }
-    
-    
+
     //Testing Function
     public List<ParseNode> getChildren()
     {
         return childNodes;
     }
 
+    public void GetTerminals(List<ParseNode> terminalList)
+    {
+        if (this.type is NodeType.Terminal)
+        {
+            terminalList.Add(this);
+            return;
+        }
+        foreach (var childNode in this.childNodes)
+        {
+            childNode.GetTerminals(terminalList);
+        }
+    }
+    
     public override string ToString()
     {
-        return type.ToString();
+        return token != null ? $"{type.ToString()}: {token.Word}" : type.ToString();
     }
 }

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -29,7 +29,7 @@ public class Parser : InterpreterLogger
 	private TokenType _tokenType;
 	private int _currentIndex;
 	private int _totalTokens;
-	private List<Token> _tokens; //TODO - define max with the group
+	private List<Token> _tokens;
 	private List<ParseNode> _parseTree = new();
 
 	private delegate void Delegate(ParseNode node);
@@ -94,10 +94,10 @@ public class Parser : InterpreterLogger
 		}
 		return true;
 	}
+	//TODO - Merge both together
 	private void Set(int index)
     {
 		_currentIndex = index;
-		//TODO - Change to index token type?
 		_tokenType = _tokens[_currentIndex].Type;
     }
 	private void Reset()
@@ -112,6 +112,7 @@ public class Parser : InterpreterLogger
 	}
     #endregion
 
+    //TODO - Investigate if this is correct use of delegates
     private ParseNode CreateNode(NodeType type, Delegate func)
     {
 	    ParseNode newNode = new ParseNode(type);
@@ -123,7 +124,6 @@ public class Parser : InterpreterLogger
 
 	public int Parse(List<Token> tokens)
 	{
-		//TODO - recreate parse tree
 		_tokens = tokens;
 		_totalTokens = tokens.Count;
 		_parseTree = new();
@@ -145,33 +145,29 @@ public class Parser : InterpreterLogger
 		}
 		
 		if (_currentIndex >= _totalTokens) return 0;
+		
+		//TODO - Improve logging overall
 		_logger.Error("Syntax error! Could not parse Token: {@token}", _tokens[_currentIndex]); //todo - Create test for this!
 		return 1;
 	}
 	
 	//EBNF Functions
-	
 	private void Statement(ParseNode node)
 	{
 		int currentIndex = _currentIndex;
-		//Remove expression try-catch when variables added
+		
+		//TODO - Remove expression and logic statements
 		try
 		{
-			ParseNode expressionNode = new ParseNode(NodeType.Expression);
-			Expression(expressionNode);
-
-			if (_currentIndex == _totalTokens)
-			{
-				node.AddChild(expressionNode);
-			}
+			node.AddChild(CreateNode(NodeType.Expression, Expression));
+			currentIndex = _currentIndex;
+			return;
 		}
 		catch (Exception e)
 		{
 			_logger.Warning(e.Message);
+			Set(currentIndex);
 		}
-		if (_currentIndex >= _totalTokens) return; //todo - check if this is redundant
-		Set(currentIndex);
-		
 		try
 		{
 			node.AddChild(CreateNode(NodeType.Conditional, IfStatements));
@@ -195,12 +191,12 @@ public class Parser : InterpreterLogger
 			_logger.Warning(e.Message);
 			Set(currentIndex);
 		}
-
-
+		
 		try
 		{
 			node.AddChild(CreateNode(NodeType.DeclareVariable, DeclareVariable));
 			currentIndex = _currentIndex;
+			return;
 		}
 		catch (Exception e)
 		{
@@ -211,6 +207,7 @@ public class Parser : InterpreterLogger
 		{
 			node.AddChild(CreateNode(NodeType.VarAssignment, VarAssignment));
 			currentIndex = _currentIndex;
+			return;
 		}
 		catch (Exception e)
 		{
@@ -218,24 +215,23 @@ public class Parser : InterpreterLogger
 			Set(currentIndex);
 		}
 
-
-
-		//TODO - Wrap this in a try catch and throw another exception in catch
 		try
 		{
 			node.AddChild(CreateNode(NodeType.LogicStatement, LogicStatement));
 			currentIndex = _currentIndex;
+			return;
 		}
 		catch (Exception e)
 		{
 			_logger.Warning(e.Message);
 			Set(currentIndex);
-			throw new Exception("Syntax error! invalid statement");
 		}
-		
+		throw new Exception("Syntax error! invalid statement");
 
 	}
+	
 	#region Variables
+	//TODO - Probably needs moving to helper methods
 	private bool CheckVarLiteral()
 	{
 		var word = _tokens[_currentIndex].Word;
@@ -246,9 +242,9 @@ public class Parser : InterpreterLogger
 		_logger.Error($"Var parse error! Expected variable literal, actual: \"{word}\"");
 		return false;
 	}
+	//TODO - Rename to match ebnf (Declaration)
 	private void DeclareVariable(ParseNode node)
 	{
-		//_logger.Information("DeclareVariable() called at level {level}", level);
 		// check for String token with the name "var"
 		if (Match(TokenType.String) && CheckVarLiteral())
 		{
@@ -258,8 +254,9 @@ public class Parser : InterpreterLogger
 		else
 		{
 			_logger.Error("Syntax Error! variable is not declared, expected \"var\" actual: {@word} ", _tokens[_currentIndex].Word);
-			return;
+			throw new SyntaxErrorException();
 		}
+		
 		int Rein = _currentIndex;
 		// check if a value is being assigned
 		try
@@ -272,18 +269,20 @@ public class Parser : InterpreterLogger
 			Set(Rein);
 			_logger.Warning(e.Message);
 		}
-		try
+		
+		node.AddChild(CreateNode(NodeType.VarIdentifier, VarIdentifier));
+		if (Match(TokenType.SemiColon))
 		{
-			node.AddChild(CreateNode(NodeType.VarIdentifier, VarIdentifier));
-			return;
+			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
+			Advance();
 		}
-		catch (Exception e)
+		else
 		{
-			_logger.Warning(e.Message);
+			_logger.Error("Syntax Error! declaration is not closed, expected \";\" actual: {@word} ", _tokens[_currentIndex].Word);
+			throw new SyntaxErrorException();
 		}
-
 	}
-
+	//TODO - Rename to match ebnf (Identifier)
 	private void VarIdentifier(ParseNode node)
 	{
 		if (Match(TokenType.String))
@@ -294,53 +293,30 @@ public class Parser : InterpreterLogger
 		else
 		{
 			_logger.Error("Syntax Error! variable does not have a name, expected \"X\" actual: {@word} ", _tokens[_currentIndex].Word);
-			return;
-		}
-		if (Match(TokenType.SemiColon))
-		{
-			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
-			Advance();
-		}
-		else
-		{
-			_logger.Error("Syntax Error! declaration is not closed, expected \";\" actual: {@word} ", _tokens[_currentIndex].Word);
-			return;
+			throw new SyntaxErrorException();
 		}
 	}
+	//TODO - Rename to match ebnf (Assignment)
 	private void VarAssignment(ParseNode node)
 	{
-		// check for String token (variable name)
-		if (Match(TokenType.String))
-		{
-			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
-			Advance();
-		}
-		else
-		{
-			_logger.Error("Syntax Error! variable does not have a name, expected \"X\" actual: {@word} ", _tokens[_currentIndex].Word);
-			return;
-		}
+		// check for identifier
+		node.AddChild(CreateNode(NodeType.VarIdentifier, VarIdentifier));
+
+		if (!Match(TokenType.Assignment)) throw new SyntaxErrorException();
+		node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
+		Advance();
+		
+		//TODO - Also try check for word, and logic statement
 		try
 		{
-			if (Match(TokenType.Assignment))
-			{
-				node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
-				Advance();
-			}
-			try
-			{
-				node.AddChild(CreateNode(NodeType.Expression, Expression));
-			}
-			catch (Exception e)
-			{
-				_logger.Warning(e.Message);
-			}
+			node.AddChild(CreateNode(NodeType.Expression, Expression));
 		}
-
 		catch (Exception e)
 		{
 			_logger.Warning(e.Message);
+			throw new SyntaxErrorException("invalid assignment expression");
 		}
+		
 		if (Match(TokenType.SemiColon))
 		{
 			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
@@ -349,10 +325,11 @@ public class Parser : InterpreterLogger
 		else
 		{
 			_logger.Error("Syntax Error! declaration is not closed, expected \";\" actual: {@word} ", _tokens[_currentIndex].Word);
-			return;
+			throw new SyntaxErrorException();
 		}
 	}
 	#endregion
+	
 	#region Expressions
 	private void Expression(ParseNode node)
 	{

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -176,6 +176,7 @@ public class Parser : InterpreterLogger
 		{
 			node.AddChild(CreateNode(NodeType.Conditional, IfStatements));
 			currentIndex = _currentIndex;
+			return;
 		}
 		catch (Exception e)
 		{
@@ -187,6 +188,7 @@ public class Parser : InterpreterLogger
 		{
 			node.AddChild(CreateNode(NodeType.WhileStatement, WhileStatement));
 			currentIndex = _currentIndex;
+			return;
 		}
 		catch (Exception e)
 		{
@@ -194,7 +196,19 @@ public class Parser : InterpreterLogger
 			Set(currentIndex);
 		}
 		//TODO - Wrap this in a try catch and throw another exception in catch
-		node.AddChild(CreateNode(NodeType.LogicStatement, LogicStatement));
+		try
+		{
+			node.AddChild(CreateNode(NodeType.LogicStatement, LogicStatement));
+			currentIndex = _currentIndex;
+		}
+		catch (Exception e)
+		{
+			_logger.Warning(e.Message);
+			Set(currentIndex);
+			throw new Exception("Syntax error! invalid statement");
+		}
+		
+
 	}
 
     #region Expressions

--- a/C_Flat_Interpreter/Transpiler/Transpiler.cs
+++ b/C_Flat_Interpreter/Transpiler/Transpiler.cs
@@ -1,4 +1,5 @@
-﻿using C_Flat_Interpreter.Common;
+﻿using System.Diagnostics.SymbolStore;
+using C_Flat_Interpreter.Common;
 using C_Flat_Interpreter.Common.Enums;
 using Serilog;
 
@@ -12,39 +13,137 @@ public class Transpiler : InterpreterLogger
         @"Console.WriteLine(""Hello, World!"");",
     };
 
+    private int _currentLine;
+    private string _program;
     public Transpiler()
     {
         GetLogger("Transpiler");
     }
-
-    public string Transpile(List<Token> tokens)
+    
+    //Helper functions
+    private void PrintTerminal(ParseNode node)
     {
-        //Retrieve program.cs file
-        var writer = File.CreateText(GetProgramPath());
-        string prog = $@"Console.Out.WriteLine(";
-        foreach (var tok in tokens)
+        var tokenToPrint = node.token ?? 
+                           throw new NullReferenceException("Node is marked as terminal but has no token");
+        if (tokenToPrint.Line > _currentLine)
         {
-            switch (tok.Type)
-            {
-                //TODO: Refactor this if needed
-                case TokenType.Sub when prog.EndsWith('-'):
-                    prog += ' ';
-                    break;
-                case TokenType.And:
-                    tok.Value = "&&";
-                    break;
-                case TokenType.Or:
-                    tok.Value = "||";
-                    break;
-            }
-            prog += (tok.Value ?? tok.Word);
+            _currentLine++;
+            _program += Environment.NewLine;
         }
-        prog += @");";
-        writer.Write(prog);
-        writer.Close();
-        return prog;
+        _program += tokenToPrint.Word;
     }
 
+
+    public string Transpile(List<ParseNode> parseTree)
+    {
+        //Retrieve program.cs file
+        _program = string.Empty;
+        var writer = File.CreateText(GetProgramPath());
+        foreach (var node in parseTree)
+        {
+            foreach (var statement in node.getChildren())
+            {
+                switch (statement.type)
+                {
+                    case NodeType.LogicStatement:
+                        _program += @"Console.WriteLine(";
+                        TranspileLogicStatement(statement);
+                        _program += @");";
+                        break;
+                    case NodeType.Expression:
+                        _program += @"Console.WriteLine(";
+                        TranspileExpression(statement);
+                        _program += @");";
+                        break;
+                    case NodeType.Conditional:
+                        break;
+                    default:
+                        _logger.Error("Unhandled statement");
+                        break;
+                }
+            }
+        }
+        writer.Write(_program);
+        writer.Close();
+        return _program;
+    }
+
+    private void TranspileExpression(ParseNode node)
+    {
+        List<ParseNode> terminals = new List<ParseNode>();
+        node.GetTerminals(terminals);
+        foreach (var terminal in terminals)
+        {
+            PrintTerminal(terminal);
+        }
+    }
+    private void TranspileExpressionQuery(ParseNode node)
+    {
+        var firstExpression = node.getChildren().First();
+        TranspileExpression(firstExpression);
+        
+        var comparisonOp = node.getChildren()[1];
+        PrintTerminal(comparisonOp);
+        
+        var secondExpression = node.getChildren().Last();
+        TranspileExpression(secondExpression);
+    }
+
+    private void TranspileBoolean(ParseNode node)
+    {
+        var booleanChild = node.getChildren().First();
+        switch (booleanChild.type)
+        {
+            case NodeType.Terminal:
+                if(booleanChild.getChildren().Count == 1)
+                    //Boolean is true or false literal
+                    PrintTerminal(booleanChild);
+
+                else if(booleanChild.getChildren().First().token?.Type is TokenType.Not)
+                {
+                    //It's a !<logic-statement>
+                    PrintTerminal(booleanChild.getChildren().First());
+                    TranspileLogicStatement(booleanChild.getChildren()[1]);
+                }
+                else
+                {
+                    //It's a (Logic-Statement>)
+                    PrintTerminal(booleanChild.getChildren().First());
+                    TranspileLogicStatement(booleanChild.getChildren()[1]);
+                    PrintTerminal(booleanChild.getChildren().Last());
+                }
+                break;
+            
+            case NodeType.ExpressionQuery:
+                TranspileExpressionQuery(booleanChild);
+                break;
+        }
+    }
+
+    private void TranspileCondition(ParseNode node)
+    {
+        var conditionComparison = node.getChildren().First();
+        PrintTerminal(conditionComparison);
+        if(conditionComparison.token?.Type is TokenType.And or TokenType.Or)
+        {
+            //For and/or we add the token word twice because we don't do bitwise logic
+            _program += conditionComparison.token?.Word;
+        }
+        var conditionBoolean = node.getChildren().Last();
+        TranspileBoolean(conditionBoolean);
+    }
+
+    private void TranspileLogicStatement(ParseNode node)
+    {
+        var boolean = node.getChildren().First();
+        TranspileBoolean(boolean);
+        
+        //TODO: Fix parser so that empty conditionals aren't added!!!
+        if(node.getChildren().Count == 2 && node.getChildren().Last().getChildren().Count > 0)
+            TranspileCondition(node.getChildren().Last());
+    }
+     
+    
     public string GetProgramPath()
     {
         return Path.GetFullPath("../../../../C_Flat_Output/Program.cs");

--- a/C_Flat_Interpreter/Transpiler/Transpiler.cs
+++ b/C_Flat_Interpreter/Transpiler/Transpiler.cs
@@ -27,7 +27,7 @@ public class Transpiler : InterpreterLogger
                            throw new NullReferenceException("Node is marked as terminal but has no token");
         if (tokenToPrint.Line > _currentLine)
         {
-            _currentLine++;
+            _currentLine = tokenToPrint.Line;
             _program += Environment.NewLine;
         }
         _program += tokenToPrint.Word;

--- a/C_Flat_Interpreter/Transpiler/Transpiler.cs
+++ b/C_Flat_Interpreter/Transpiler/Transpiler.cs
@@ -17,7 +17,7 @@ public class Transpiler : InterpreterLogger
         GetLogger("Transpiler");
     }
 
-    public void Transpile(List<Token> tokens)
+    public string Transpile(List<Token> tokens)
     {
         //Retrieve program.cs file
         var writer = File.CreateText(GetProgramPath());
@@ -42,6 +42,7 @@ public class Transpiler : InterpreterLogger
         prog += @");";
         writer.Write(prog);
         writer.Close();
+        return prog;
     }
 
     public string GetProgramPath()

--- a/C_Flat_Output/Program.cs
+++ b/C_Flat_Output/Program.cs
@@ -1,1 +1,2 @@
-Console.Out.WriteLine();
+Console.WriteLine(100<20);Console.WriteLine(
+200>100);

--- a/C_Flat_Output/Program.cs
+++ b/C_Flat_Output/Program.cs
@@ -1,2 +1,1 @@
-// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+Console.WriteLine(100 - 20 );

--- a/C_Flat_Output/Program.cs
+++ b/C_Flat_Output/Program.cs
@@ -1,2 +1,1 @@
-// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+Console.Out.WriteLine(testing);

--- a/C_Flat_Output/Program.cs
+++ b/C_Flat_Output/Program.cs
@@ -1,1 +1,1 @@
-Console.Out.WriteLine(testing);
+Console.Out.WriteLine();

--- a/C_Flat_Output/Program.cs
+++ b/C_Flat_Output/Program.cs
@@ -1,1 +1,2 @@
-Console.WriteLine(100 - 20 );
+// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/C_Flat_Tests/Tests_Unit/TranspilerUnit.cs
+++ b/C_Flat_Tests/Tests_Unit/TranspilerUnit.cs
@@ -9,31 +9,44 @@ namespace C_Flat_Tests.Tests_Unit;
 public class TranspilerUnit : TestLogger
 {
     private readonly Transpiler _transpiler = new();
+    private readonly List<ParseNode> _parseTree;
     public TranspilerUnit()
-    { 
+    {
+        _parseTree = new();
         GetLogger("Execution Unit Tests");
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        _parseTree.Clear();
     }
 
     [Test]
     public void Transpiler_Transpile_WritesStringToFile()
     {
         //Arrange
-        string testInput = @"Console.WriteLine(""Hello World!"");";
-        List<Token> input = new List<Token>
-        {
-            new(TokenType.Num, 10),
-            new(TokenType.Add)
-            {
-                Word = "+"
-            },
-            new(TokenType.Num, 20),
-        };
+        var statement = new ParseNode(NodeType.Statement);
+        var declaration = new ParseNode(NodeType.DeclareVariable);
+        
+        declaration.AddChild(new (NodeType.Terminal, new Token(TokenType.String){Word = "var"}));
+        
+        var identifier = new ParseNode(NodeType.VarIdentifier);
+        identifier.AddChild(new(NodeType.Terminal, new Token(TokenType.String) {Word = "test"}));
+        declaration.AddChild(identifier);
+        
+        declaration.AddChild(new (NodeType.Terminal, new Token(TokenType.SemiColon){Word = ";"}));
+        
+        statement.AddChild(declaration);
+        _parseTree.Add(statement);
+        
         //Act
-        _transpiler.Transpile(input);
+        var success = _transpiler.Transpile(_parseTree);
         var testOutput = File.ReadAllText(_transpiler.GetProgramPath());
-
+        
         //Assert
-        Assert.That(testOutput, Contains.Substring("10+20"));
+        Assert.That(success, Is.EqualTo(0));
+        Assert.That(testOutput, Contains.Substring("var test"));
     }
 
     [TearDown]


### PR DESCRIPTION
## Changes:

1. Refactored GUI to improve user experience
2. Added parse tree visualisation within GUI
3. Added view for showing C# output
4. Added other various small animations/ QOL UI changes
5. Moved parser `NodeType` to enums folder
6. Made `ParseNode` fields public for accessibility (See comments for further discussion)
7. Added  `GetTerminals()` to `ParseNode` (As above)
8. Overrode `ParseNode` `ToString()`
9. Cleaned up some `TODO`'s that had already been completed
10. Added `TODO`'s 
11. Modified `Parser.cs` variable code to fix some errors. (Discussed below)
12. Added `Transpiler` support for variables with some caveats (as above)
13. Added simple unit test to `Transpiler`

## Considerations:

### 6:
These fields could probably be replaced with properties, additionally it might be worth rethinking our constructors / adding additional helper methods for things like getting children at a certain index. Currently I manually do this in Transpiler, but having a method that throws an exception would aid in error handling.
### 7:
I've only used this in expression as I was lazy, it really shouldn't need to exist and I should do the tree traversal manually as I have with other types of node (see `TranspileDeclaration()`). I'm happy to remove it prior to merging or I can do that in a future PR
### 11:
I'll add these in as comments on individual lines for better visibility but I'll summarise here. Overall most of the variable parsing code worked great, just found a few hidden bugs that got merged. 
- The main issue was that the `VarAssignment()` method wasn't throwing exceptions when it ran into an incorrect token. It was logging errors however, but it needed to throw instead (/aswell? #19) 
- Additionally in `Statement()` the added try catches weren't returning after a successful parse which caused a few issues.
- A small change was just to use `VarIdentifier()` within `VarAssignment()` which removed duplicate code, additionally to match our BNF the check for a semicolon was moved to the end of `DeclareVariable()`

### 12:
There are 2 main caveats with variable support right now:
1. Due to our ignoring of whitespace, when the transpiler writes to the `Program.cs` file it doesn't include any spaces between tokens, resulting in `var i = 20;` becoming `vari=20;` which throws an error when compiled. I fixed this by just including a space between each token but this needs to be properly addressed within `Lexer` (perhaps with `Token.word` including preceding whitespaces?)

2. Our BNF/Parser currently allows users to declare variables without assigning them an initial value, this results in a compilation error within C# as by default C# requires implicit (`var`) variables to have an assignment to determine the type. We can either adapt our BNF to require the user to assign a value when first declaring a variable (easy method) or when the variable look-up table is implemented we can try to determine the type during the Transpilation stage based on the first value assigned to a variable. 

### Additional thoughts:
- Currently `Token` has a field for `Value` but this is pretty much redundant and used basically nowhere. It would be better to simply have "Word" and let the Transpiler deduce the value. Though this is sort of related to the above so happy to leave/discuss later. 

- Logging desperately needs a refactor see  #19
