### PR TITLE
Handling whitespace in Lexer.cs

### DIFF
--- a/C_Flat_Interpreter/Lexer/Lexer.cs
+++ b/C_Flat_Interpreter/Lexer/Lexer.cs
@@ -15,7 +15,6 @@ using System.Collections.Generic;
 public class Lexer : InterpreterLogger
 {
     private readonly List<Token> _tokens = new(); //TODO - define max with the group
-    private string _input;
     private bool _failed;
     private string[] _lines;
 
@@ -40,9 +39,8 @@ public class Lexer : InterpreterLogger
     {
         _failed = false;
         _tokens.Clear();
-        _input = input;
-        
-        var _whitespace = "";
+
+        var whitespace = "";
 
         input = input.Replace("\r", "");
         _lines = input.Split("\n");
@@ -52,62 +50,64 @@ public class Lexer : InterpreterLogger
             for(int i = 0; i < _lines[j].Length; i++) //character
             {
                 char c = _lines[j][i];
-                var newToken = new Token();
-                newToken.Line = j;
+                var newToken = new Token
+                {
+                    Line = j
+                };
 
                 switch (c)
                 {
                     case ' ':
-                        _whitespace += " ";
+                        whitespace += " ";
                         newToken = null;
                         break;
                     case ';':
                         newToken.Type = TokenType.SemiColon;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '+':
                         newToken.Type = TokenType.Add;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '*':
                         newToken.Type = TokenType.Multi;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '(':
                         newToken.Type = TokenType.LeftParen;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case ')':
                         newToken.Type = TokenType.RightParen;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '{':
                         newToken.Type = TokenType.LeftCurlyBrace;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '}':
                         newToken.Type = TokenType.RightCurlyBrace;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '-':
                         newToken.Type = TokenType.Sub;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '/':
                         newToken.Type = TokenType.Divide;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '!':
                         if (_lines[j][i + 1] == '=')
                         {
                             i++;
                             newToken.Type = TokenType.NotEqual;
-                            newToken.Word = _whitespace + c + _lines[j][i];
+                            newToken.Word = whitespace + c + _lines[j][i];
                         }
                         else
                         {
                             newToken.Type = TokenType.Not;
-                            newToken.Word = _whitespace + c;
+                            newToken.Word = whitespace + c;
                         }
                         break;
                     case '=':
@@ -115,47 +115,47 @@ public class Lexer : InterpreterLogger
                         {
                             i++;
                             newToken.Type = TokenType.Equals;
-                            newToken.Word = _whitespace + c + _lines[j][i];
+                            newToken.Word = whitespace + c + _lines[j][i];
                         }
                         else
                         {
                             newToken.Type = TokenType.Assignment;
-                            newToken.Word = _whitespace + c;
+                            newToken.Word = whitespace + c;
                         }
 
                         break;
                     case '&':
                         newToken.Type = TokenType.And;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '|':
                         newToken.Type = TokenType.Or;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '<':
                         newToken.Type = TokenType.Less;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     case '>':
                         newToken.Type = TokenType.More;
-                        newToken.Word = _whitespace + c;
+                        newToken.Word = whitespace + c;
                         break;
                     default:
                         if (char.IsDigit(c))
                         {
                             newToken.Type = TokenType.Num;
                             var num = ParseNumber(j, i);
-                            newToken.Word = _whitespace + num;
+                            newToken.Word = whitespace + num;
                             i += num.Length - 1;
-                            newToken.Value = double.Parse(newToken.Word);
+                            newToken.Value = double.Parse(num);
                         }
                         else if (char.IsLetter(c))
                         {
                             newToken.Type = TokenType.String;
                             var letters = ParseWord(j, i);
-                            newToken.Word = _whitespace + letters;
+                            newToken.Word = whitespace + letters;
                             i += letters.Length - 1;
-                            newToken.Value = newToken.Word;
+                            newToken.Value = letters;
                         }
                         else
                         {
@@ -163,17 +163,14 @@ public class Lexer : InterpreterLogger
                             _logger.Error("Invalid lexeme encountered! Disregarding: {invalidToken}", c.ToString());
                             _failed = true;
                         }
-
                         break;
                 }
 
-                if (newToken != null)
-                {
-                    _tokens.Add(newToken);
-                    _whitespace = "";
-                }
+                if (newToken == null) continue;
+                _tokens.Add(newToken);
+                whitespace = "";
             }
-            _whitespace = "";
+            whitespace = "";
         }
         return _failed ? 1 : 0;
     }

--- a/C_Flat_Interpreter/Lexer/Lexer.cs
+++ b/C_Flat_Interpreter/Lexer/Lexer.cs
@@ -41,6 +41,8 @@ public class Lexer : InterpreterLogger
         _failed = false;
         _tokens.Clear();
         _input = input;
+        
+        var _whitespace = "";
 
         input = input.Replace("\r", "");
         _lines = input.Split("\n");
@@ -56,56 +58,56 @@ public class Lexer : InterpreterLogger
                 switch (c)
                 {
                     case ' ':
-                        //ignore whitespace
+                        _whitespace += " ";
                         newToken = null;
                         break;
                     case ';':
                         newToken.Type = TokenType.SemiColon;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '+':
                         newToken.Type = TokenType.Add;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '*':
                         newToken.Type = TokenType.Multi;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '(':
                         newToken.Type = TokenType.LeftParen;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case ')':
                         newToken.Type = TokenType.RightParen;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '{':
                         newToken.Type = TokenType.LeftCurlyBrace;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '}':
                         newToken.Type = TokenType.RightCurlyBrace;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '-':
                         newToken.Type = TokenType.Sub;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '/':
                         newToken.Type = TokenType.Divide;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '!':
                         if (_lines[j][i + 1] == '=')
                         {
                             i++;
                             newToken.Type = TokenType.NotEqual;
-                            newToken.Word = c.ToString() + _lines[j][i].ToString();
+                            newToken.Word = _whitespace + c + _lines[j][i];
                         }
                         else
                         {
                             newToken.Type = TokenType.Not;
-                            newToken.Word = c.ToString();
+                            newToken.Word = _whitespace + c;
                         }
                         break;
                     case '=':
@@ -113,44 +115,46 @@ public class Lexer : InterpreterLogger
                         {
                             i++;
                             newToken.Type = TokenType.Equals;
-                            newToken.Word = c.ToString() + _lines[j][i].ToString();
+                            newToken.Word = _whitespace + c + _lines[j][i];
                         }
                         else
                         {
                             newToken.Type = TokenType.Assignment;
-                            newToken.Word = c.ToString();
+                            newToken.Word = _whitespace + c;
                         }
 
                         break;
                     case '&':
                         newToken.Type = TokenType.And;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '|':
                         newToken.Type = TokenType.Or;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '<':
                         newToken.Type = TokenType.Less;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     case '>':
                         newToken.Type = TokenType.More;
-                        newToken.Word = c.ToString();
+                        newToken.Word = _whitespace + c;
                         break;
                     default:
                         if (char.IsDigit(c))
                         {
                             newToken.Type = TokenType.Num;
-                            newToken.Word = ParseNumber(j, i);
-                            i += newToken.Word.Length - 1;
+                            var num = ParseNumber(j, i);
+                            newToken.Word = _whitespace + num;
+                            i += num.Length - 1;
                             newToken.Value = double.Parse(newToken.Word);
                         }
                         else if (char.IsLetter(c))
                         {
                             newToken.Type = TokenType.String;
-                            newToken.Word = ParseWord(j, i);
-                            i += newToken.Word.Length - 1;
+                            var letters = ParseWord(j, i);
+                            newToken.Word = _whitespace + letters;
+                            i += letters.Length - 1;
                             newToken.Value = newToken.Word;
                         }
                         else
@@ -166,8 +170,10 @@ public class Lexer : InterpreterLogger
                 if (newToken != null)
                 {
                     _tokens.Add(newToken);
+                    _whitespace = "";
                 }
             }
+            _whitespace = "";
         }
         return _failed ? 1 : 0;
     }

--- a/C_Flat_Interpreter/Lexer/Lexer.cs
+++ b/C_Flat_Interpreter/Lexer/Lexer.cs
@@ -58,7 +58,7 @@ public class Lexer : InterpreterLogger
                 switch (c)
                 {
                     case ' ':
-                        whitespace += " ";
+                        whitespace += c;
                         newToken = null;
                         break;
                     case ';':
@@ -122,7 +122,6 @@ public class Lexer : InterpreterLogger
                             newToken.Type = TokenType.Assignment;
                             newToken.Word = whitespace + c;
                         }
-
                         break;
                     case '&':
                         newToken.Type = TokenType.And;
@@ -147,15 +146,13 @@ public class Lexer : InterpreterLogger
                             var num = ParseNumber(j, i);
                             newToken.Word = whitespace + num;
                             i += num.Length - 1;
-                            newToken.Value = double.Parse(num);
                         }
                         else if (char.IsLetter(c))
                         {
                             newToken.Type = TokenType.String;
-                            var letters = ParseWord(j, i);
+                            var letters = ParseString(j, i);
                             newToken.Word = whitespace + letters;
                             i += letters.Length - 1;
-                            newToken.Value = letters;
                         }
                         else
                         {
@@ -198,7 +195,7 @@ public class Lexer : InterpreterLogger
         }
         return numberString;
     }
-    private string ParseWord(int line, int index)
+    private string ParseString(int line, int index)
     {
         var wordString = _lines[line][index].ToString();
         while (index+1 < _lines[line].Length)

--- a/C_Flat_Interpreter/Lexer/Lexer.cs
+++ b/C_Flat_Interpreter/Lexer/Lexer.cs
@@ -112,7 +112,7 @@ public class Lexer : InterpreterLogger
                         if (_lines[j][i + 1] == '=')
                         {
                             i++;
-                            newToken.Type = TokenType.NotEqual;
+                            newToken.Type = TokenType.Equals;
                             newToken.Word = c.ToString() + _lines[j][i].ToString();
                         }
                         else

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -50,30 +50,30 @@ public class Parser : InterpreterLogger
     #region Helper Functions
 	private bool CheckBoolLiteral()
 	{
-		var word = _tokens[_currentIndex].Word;
-		if (word.Equals("true") || word.Equals("false")) return true;
-		_logger.Error($"Bool parse error! Expected boolean literal, actual: \"{word}\"");
+		var value = _tokens[_currentIndex].Value;
+		if (value.Equals("true") || value.Equals("false")) return true;
+		_logger.Error($"Bool parse error! Expected boolean literal, actual: \"{value}\"");
 		return false;
 	}
 	private bool CheckIf()
     {
-		var word = _tokens[_currentIndex].Word;
-		if (word.Equals("if")) return true;
-		_logger.Error($"If parse error! Expected if, actual: \"{word}\"");
+		var value = _tokens[_currentIndex].Value;
+		if (value.Equals("if")) return true;
+		_logger.Error($"If parse error! Expected if, actual: \"{value}\"");
 		return false;
 	}
 	private bool CheckElse()
 	{
-		var word = _tokens[_currentIndex].Word;
-		if (word.Equals("else")) return true;
-		_logger.Error($"Else parse error! Expected else, actual: \"{word}\"");
+		var value = _tokens[_currentIndex].Value;
+		if (value.Equals("else")) return true;
+		_logger.Error($"Else parse error! Expected else, actual: \"{value}\"");
 		return false;
 	}
 	private bool CheckWhile()
 	{
-		var word = _tokens[_currentIndex].Word;
-		if (word.Equals("while")) return true;
-		_logger.Error($"While parse error! Expected while, actual: \"{word}\"");
+		var value = _tokens[_currentIndex].Value;
+		if (value.Equals("while")) return true;
+		_logger.Error($"While parse error! Expected while, actual: \"{value}\"");
 		return false;
 	}
 	private bool Match(TokenType tokenType)
@@ -234,12 +234,12 @@ public class Parser : InterpreterLogger
 	//TODO - Probably needs moving to helper methods
 	private bool CheckVarLiteral()
 	{
-		var word = _tokens[_currentIndex].Word;
-		if (word.Equals("var"))
+		var value = _tokens[_currentIndex].Value;
+		if (value.Equals("var"))
 		{
 			return true;
 		}
-		_logger.Error($"Var parse error! Expected variable literal, actual: \"{word}\"");
+		_logger.Error($"Var parse error! Expected variable literal, actual: \"{value}\"");
 		return false;
 	}
 	//TODO - Rename to match ebnf (Declaration)

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -50,32 +50,44 @@ public class Parser : InterpreterLogger
     #region Helper Functions
 	private bool CheckBoolLiteral()
 	{
-		var value = _tokens[_currentIndex].Value;
-		if (value.Equals("true") || value.Equals("false")) return true;
-		_logger.Error($"Bool parse error! Expected boolean literal, actual: \"{value}\"");
+		var word = _tokens[_currentIndex].Word.Trim();
+		if (word.Equals("true") || word.Equals("false")) return true;
+		_logger.Error($"Bool parse error! Expected boolean literal, actual: \"{word}\"");
 		return false;
 	}
 	private bool CheckIf()
     {
-		var value = _tokens[_currentIndex].Value;
-		if (value.Equals("if")) return true;
-		_logger.Error($"If parse error! Expected if, actual: \"{value}\"");
+		var word = _tokens[_currentIndex].Word.Trim();
+		if (word.Equals("if")) return true;
+		_logger.Error($"If parse error! Expected if, actual: \"{word}\"");
 		return false;
 	}
 	private bool CheckElse()
 	{
-		var value = _tokens[_currentIndex].Value;
-		if (value.Equals("else")) return true;
-		_logger.Error($"Else parse error! Expected else, actual: \"{value}\"");
+		var word = _tokens[_currentIndex].Word.Trim();
+		if (word.Equals("else")) return true;
+		_logger.Error($"Else parse error! Expected else, actual: \"{word}\"");
 		return false;
 	}
 	private bool CheckWhile()
 	{
-		var value = _tokens[_currentIndex].Value;
-		if (value.Equals("while")) return true;
-		_logger.Error($"While parse error! Expected while, actual: \"{value}\"");
+		var word = _tokens[_currentIndex].Word.Trim();
+		if (word.Equals("while")) return true;
+		_logger.Error($"While parse error! Expected while, actual: \"{word}\"");
 		return false;
 	}
+	
+	private bool CheckVarLiteral()
+	{
+		var word = _tokens[_currentIndex].Word.Trim();
+		if (word.Equals("var"))
+		{
+			return true;
+		}
+		_logger.Error($"Var parse error! Expected variable literal, actual: \"{word}\"");
+		return false;
+	}
+	
 	private bool Match(TokenType tokenType)
 	{
 		if (_tokenType == TokenType.Null) //only on first call,  TODO - find better way to do this that means we don't need to set to null and/or we don't need this check
@@ -231,17 +243,6 @@ public class Parser : InterpreterLogger
 	}
 	
 	#region Variables
-	//TODO - Probably needs moving to helper methods
-	private bool CheckVarLiteral()
-	{
-		var value = _tokens[_currentIndex].Value;
-		if (value.Equals("var"))
-		{
-			return true;
-		}
-		_logger.Error($"Var parse error! Expected variable literal, actual: \"{value}\"");
-		return false;
-	}
 	//TODO - Rename to match ebnf (Declaration)
 	private void DeclareVariable(ParseNode node)
 	{

--- a/C_Flat_Interpreter/Transpiler/Transpiler.cs
+++ b/C_Flat_Interpreter/Transpiler/Transpiler.cs
@@ -31,7 +31,7 @@ public class Transpiler : InterpreterLogger
             Program += Environment.NewLine;
         }
         //Consider handling empty spaces within lexer
-        Program += tokenToPrint.Word + " ";
+        Program += tokenToPrint.Word;
     }
 
 

--- a/C_Flat_Tests/Tests_Unit/LexerUnit.cs
+++ b/C_Flat_Tests/Tests_Unit/LexerUnit.cs
@@ -30,6 +30,10 @@ public class LexerUnit
                              "}";
         _lexer.Tokenise(input);
         Assert.That(_lexer.GetTokens().Count == 7);
+        Assert.That(_lexer.GetFromTokenList(3).Line == 0);
+        Assert.That(_lexer.GetFromTokenList(4).Line == 1);
+        Assert.That(_lexer.GetFromTokenList(5).Line == 2);
+        Assert.That(_lexer.GetFromTokenList(6).Line == 3);
     }
     
     [Test]
@@ -39,7 +43,7 @@ public class LexerUnit
         _lexer.Tokenise(input);
         var token = _lexer.GetFromTokenList(0);
         Assert.That(token.Type, Is.EqualTo(TokenType.Add));
-        Assert.That(token.Word.ToString(), Is.EqualTo(" +"));
+        Assert.That(token.Word, Is.EqualTo(" +"));
     }
     [Test]
     public void Lexer_Tokenise_LeftBrace_TokenIsLeftBrace()
@@ -48,7 +52,7 @@ public class LexerUnit
         _lexer.Tokenise(input);
         var token = _lexer.GetFromTokenList(2);
         Assert.That(token.Type, Is.EqualTo(TokenType.LeftCurlyBrace));
-        Assert.That(token.Word.ToString(), Is.EqualTo('{'.ToString()));
+        Assert.That(token.Word, Is.EqualTo('{'.ToString()));
     }
     [Test]
     public void Lexer_Tokenise_RightBrace_TokenIsRightBrace()
@@ -57,7 +61,7 @@ public class LexerUnit
         _lexer.Tokenise(input);
         var token = _lexer.GetFromTokenList(3);
         Assert.That(token.Type, Is.EqualTo(TokenType.RightCurlyBrace));
-        Assert.That(token.Word.ToString(), Is.EqualTo('}'.ToString()));
+        Assert.That(token.Word, Is.EqualTo('}'.ToString()));
     }
     [Test]
     public void Lexer_Tokenise_Semicolon_TokenIsSemicolon()
@@ -66,7 +70,7 @@ public class LexerUnit
         _lexer.Tokenise(input);
         var token = _lexer.GetFromTokenList(4);
         Assert.That(token.Type, Is.EqualTo(TokenType.SemiColon));
-        Assert.That(token.Word.ToString(), Is.EqualTo(";"));
+        Assert.That(token.Word, Is.EqualTo(";"));
     }
     [Test]
     public void Lexer_Tokenise_Multi_TokenIsMulti()
@@ -74,7 +78,7 @@ public class LexerUnit
         const string input = " +*()-/0123456789";
         _lexer.Tokenise(input);
         Assert.That(_lexer.GetFromTokenList(1).Type, Is.EqualTo(TokenType.Multi));
-        Assert.That(_lexer.GetFromTokenList(1).Word.ToString(), Is.EqualTo("*"));
+        Assert.That(_lexer.GetFromTokenList(1).Word, Is.EqualTo("*"));
     }
     
     [Test]
@@ -83,7 +87,7 @@ public class LexerUnit
         const string input = " +*()-/0123456789";
         _lexer.Tokenise(input);
         Assert.That(_lexer.GetFromTokenList(2).Type, Is.EqualTo(TokenType.LeftParen));
-        Assert.That(_lexer.GetFromTokenList(2).Word.ToString(), Is.EqualTo("("));
+        Assert.That(_lexer.GetFromTokenList(2).Word, Is.EqualTo("("));
     }
     
     [Test]
@@ -92,7 +96,7 @@ public class LexerUnit
         const string input = " +*()-/0123456789";
         _lexer.Tokenise(input);
         Assert.That(_lexer.GetFromTokenList(3).Type, Is.EqualTo(TokenType.RightParen));
-        Assert.That(_lexer.GetFromTokenList(3).Word.ToString(), Is.EqualTo(")"));
+        Assert.That(_lexer.GetFromTokenList(3).Word, Is.EqualTo(")"));
     }
     
     [Test]
@@ -101,7 +105,7 @@ public class LexerUnit
         const string input = " +*()-/0123456789";
         _lexer.Tokenise(input);
         Assert.That(_lexer.GetFromTokenList(4).Type, Is.EqualTo(TokenType.Sub));
-        Assert.That(_lexer.GetFromTokenList(4).Word.ToString(), Is.EqualTo("-"));
+        Assert.That(_lexer.GetFromTokenList(4).Word, Is.EqualTo("-"));
     }
     
     [Test]
@@ -109,7 +113,7 @@ public class LexerUnit
     {
         const string input = " +*()-/0123456789";
         _lexer.Tokenise(input);
-        Assert.That(_lexer.GetFromTokenList(5).Word.ToString(), Is.EqualTo("/"));
+        Assert.That(_lexer.GetFromTokenList(5).Word, Is.EqualTo("/"));
         Assert.That(_lexer.GetFromTokenList(5).Type, Is.EqualTo(TokenType.Divide));
     }
     
@@ -118,7 +122,7 @@ public class LexerUnit
     {
         const string input = "69";
         _lexer.Tokenise(input);
-        Assert.That(_lexer.GetFromTokenList(0).Word.ToString(), Is.EqualTo("69"));
+        Assert.That(_lexer.GetFromTokenList(0).Word, Is.EqualTo("69"));
         Assert.That(_lexer.GetFromTokenList(0).Type, Is.EqualTo(TokenType.Num));
         Assert.That(_lexer.GetFromTokenList(0).Value, Is.EqualTo(69));
     }
@@ -128,7 +132,7 @@ public class LexerUnit
     {
         const string input = "69.420";
         _lexer.Tokenise(input);
-        Assert.That(_lexer.GetFromTokenList(0).Word.ToString(), Is.EqualTo("69.420"));
+        Assert.That(_lexer.GetFromTokenList(0).Word, Is.EqualTo("69.420"));
         Assert.That(_lexer.GetFromTokenList(0).Type, Is.EqualTo(TokenType.Num));
         Assert.That(_lexer.GetFromTokenList(0).Value, Is.EqualTo(69.420));
     }
@@ -139,7 +143,7 @@ public class LexerUnit
         const string input = "5 ^";
         _lexer.Tokenise(input);
         var errorLogs = _lexer.GetInMemoryLogs().Where(log => log.Level > LogEventLevel.Warning);
-        Assert.That(_lexer.GetFromTokenList(0).Word.ToString(), Is.EqualTo("5"));
+        Assert.That(_lexer.GetFromTokenList(0).Word, Is.EqualTo("5"));
         Assert.That(errorLogs.Any(x => x.RenderMessage().Contains("Invalid lexeme encountered!")));
     }
 }

--- a/C_Flat_Tests/Tests_Unit/LexerUnit.cs
+++ b/C_Flat_Tests/Tests_Unit/LexerUnit.cs
@@ -39,7 +39,7 @@ public class LexerUnit
         _lexer.Tokenise(input);
         var token = _lexer.GetFromTokenList(0);
         Assert.That(token.Type, Is.EqualTo(TokenType.Add));
-        Assert.That(token.Word.ToString(), Is.EqualTo('+'.ToString()));
+        Assert.That(token.Word.ToString(), Is.EqualTo(" +"));
     }
     [Test]
     public void Lexer_Tokenise_LeftBrace_TokenIsLeftBrace()
@@ -136,11 +136,10 @@ public class LexerUnit
     [Test]
     public void Lexer_Tokenise_InvalidToken_IsHandled()
     {
-        const string input = "5 ^ 3";
+        const string input = "5 ^";
         _lexer.Tokenise(input);
         var errorLogs = _lexer.GetInMemoryLogs().Where(log => log.Level > LogEventLevel.Warning);
         Assert.That(_lexer.GetFromTokenList(0).Word.ToString(), Is.EqualTo("5"));
         Assert.That(errorLogs.Any(x => x.RenderMessage().Contains("Invalid lexeme encountered!")));
-        Assert.That(_lexer.GetFromTokenList(1).Word.ToString(), Is.EqualTo("3"));
     }
 }

--- a/C_Flat_Tests/Tests_Unit/LexerUnit.cs
+++ b/C_Flat_Tests/Tests_Unit/LexerUnit.cs
@@ -124,7 +124,6 @@ public class LexerUnit
         _lexer.Tokenise(input);
         Assert.That(_lexer.GetFromTokenList(0).Word, Is.EqualTo("69"));
         Assert.That(_lexer.GetFromTokenList(0).Type, Is.EqualTo(TokenType.Num));
-        Assert.That(_lexer.GetFromTokenList(0).Value, Is.EqualTo(69));
     }
     
     [Test]
@@ -134,7 +133,6 @@ public class LexerUnit
         _lexer.Tokenise(input);
         Assert.That(_lexer.GetFromTokenList(0).Word, Is.EqualTo("69.420"));
         Assert.That(_lexer.GetFromTokenList(0).Type, Is.EqualTo(TokenType.Num));
-        Assert.That(_lexer.GetFromTokenList(0).Value, Is.EqualTo(69.420));
     }
     
     [Test]

--- a/C_Flat_Tests/Tests_Unit/TranspilerUnit.cs
+++ b/C_Flat_Tests/Tests_Unit/TranspilerUnit.cs
@@ -32,7 +32,7 @@ public class TranspilerUnit : TestLogger
         declaration.AddChild(new (NodeType.Terminal, new Token(TokenType.String){Word = "var"}));
         
         var identifier = new ParseNode(NodeType.VarIdentifier);
-        identifier.AddChild(new(NodeType.Terminal, new Token(TokenType.String) {Word = "test"}));
+        identifier.AddChild(new(NodeType.Terminal, new Token(TokenType.String) {Word = " test"}));
         declaration.AddChild(identifier);
         
         declaration.AddChild(new (NodeType.Terminal, new Token(TokenType.SemiColon){Word = ";"}));


### PR DESCRIPTION
## Main Changes
My main goal was to allow the lexer to handle whitespaces, rather than having the transpiler do this. This was a matter of keeping track of whitespace and adding it to the front of every token's word.
I also updated the lexer unit tests to check new lines are being dealt with correctly, and that whitespace is being dealt with correctly.

### Considerations
- I decided to discard any trailing whitespace at the end of the line, otherwise it was being added to the start of the next token. I could have found a way to keep it but seen as whitespace isn't really noticeable unless there's a character after it, I didn't think it was worth it.
- I changed tokens that are strings or numbers so that their word contains any whitespace + the characters, and their value contains only the characters. I then changed the parser to look at the value rather than the word when checking for keywords. This needed to be done as the parser was checking the whitespace when looking for keywords, so '  var' would be checked for example, rather than just 'var'. This caused an error when it shouldn't. This would also need to be taken into consideration when using variable identifiers. The value would need to be checked as to not account for the whitespace. I could have taken a different approach to this (ignoring the whitespace in the parser or assigning word and value the other way around), but I felt this was the most appropriate and easy to implement option, however this should be discussed by the team to ensure we choose the right option.


## Bug Fix
- In Lexer.cs the '==' token was being set to 'NotEqual' 


