### PR TITLE
Logging refactor

### DIFF
--- a/C_Flat_GUI/MainWindow.xaml
+++ b/C_Flat_GUI/MainWindow.xaml
@@ -50,17 +50,32 @@
                                                 <Label Foreground="#C8FFFFFF" HorizontalAlignment="Center">C__Flat Source Input</Label>
                                                 <Grid Grid.Row="1" VerticalAlignment="Stretch">
                                                         <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" VerticalAlignment="Stretch">
-                                                                <ui:TextBox
-                                                                Background="#2CFFFFFF"
-                                                                Foreground="White"
-                                                                Name="SourceInput"
-                                                                TextWrapping="NoWrap"
-                                                                AcceptsReturn="True"
-                                                                AcceptsTab="True"
-                                                                VerticalScrollBarVisibility="Visible"
-                                                                HorizontalScrollBarVisibility="Visible"
-                                                                BorderThickness="0"
-                                                                VerticalAlignment="Stretch"/>
+                                                                <Grid>
+                                                                        <Grid.ColumnDefinitions>
+                                                                                <ColumnDefinition Width="35" />
+                                                                                <ColumnDefinition Width="*"/> 
+                                                                        </Grid.ColumnDefinitions>
+                                                                        <Border
+                                                                                Background="#65636363"
+                                                                                CornerRadius="3" Padding="3" Margin="0,0,3,0">
+                                                                                <TextBlock Name="LineNumbers" Padding="0,5,0,4" TextAlignment="Center">
+                                                                                        1
+                                                                                </TextBlock>
+                                                                        </Border>
+                                                                       
+                                                                        <ui:TextBox
+                                                                                Grid.Column="1"
+                                                                                Background="#2CFFFFFF"
+                                                                                Foreground="White"
+                                                                                Name="SourceInput"
+                                                                                TextWrapping="NoWrap"
+                                                                                AcceptsReturn="True"
+                                                                                AcceptsTab="True"
+                                                                                VerticalScrollBarVisibility="Visible"
+                                                                                HorizontalScrollBarVisibility="Visible"
+                                                                                BorderThickness="0"
+                                                                                VerticalAlignment="Stretch"/>
+                                                                </Grid>
                                                         </ScrollViewer>
                                                 </Grid>
                                         </Grid>
@@ -126,10 +141,10 @@
                                                 <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
                                         <ui:Card Grid.Column="0" Name="LeftButton" VerticalAlignment="Center" Background="Transparent" Padding="2,10" BorderThickness="0">
-                                                <ui:Button Name="test" Margin="5" HorizontalAlignment="Stretch" Background="#C86A1B9A">Transpile Source Input</ui:Button>
+                                                <ui:Button Margin="5" HorizontalAlignment="Stretch" Background="#C86A1B9A"> Placeholder </ui:Button>
                                         </ui:Card>
                                         <ui:Card Grid.Column="1" Name="RightButton" VerticalAlignment="Center" Background="Transparent" Padding="2,10" BorderThickness="0">
-                                                <ui:Button  Name="anotherTest" Margin="5" HorizontalAlignment="Stretch" Background="#C86A1B9A">Transpile Source Input</ui:Button>
+                                                <ui:Button Margin="5" HorizontalAlignment="Stretch" Background="#C86A1B9A"> Placeholder </ui:Button>
                                         </ui:Card>
                                 </Grid>
                                 

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -290,7 +290,7 @@ namespace C_Flat
                     _executionOutput.Inlines.Add(new Run()
                     {
                         Text = trimmedError + "\n",
-                        Background = Brushes.DarkRed,
+                        Background = trimmedError.Contains("error")? Brushes.DarkRed : Brushes.Goldenrod,
                     });
                 }
                 ExecuteButton.IsEnabled = false;

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -100,8 +100,22 @@ namespace C_Flat
             };
             OutputBorder.Child = _codeView;
             ExpandAll.Visibility = Visibility.Hidden;
+            SourceInput.TextChanged += UpdateLineNumbers;
+            LineNumbers.FontSize = SourceInput.FontSize;
         }
 
+        private void UpdateLineNumbers(object sender, TextChangedEventArgs e)
+        {
+            if (LineNumbers.Inlines.Count != SourceInput.LineCount)
+            {
+                LineNumbers.Inlines.Clear();
+                for (int i = 1; i <= SourceInput.LineCount; i++)
+                {
+                    LineNumbers.Inlines.Add(new Run(i.ToString() + "\n"));
+                }
+            }
+            
+        }
         private void ButtonTranspile_Click(object sender, RoutedEventArgs e)
         {
             _codeView.Text = "";

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -195,7 +195,7 @@ namespace C_Flat
             _codeView.Inlines.Add(new Run()
             {
                 Text = $"{stage} Failed! Printing logs: \n",
-                FontWeight = FontWeights.Bold,
+                FontWeight = FontWeights.DemiBold,
                 TextDecorations = TextDecorations.Underline,
                 FontSize = 24,
                 Background = Brushes.Transparent,
@@ -290,7 +290,7 @@ namespace C_Flat
                     _executionOutput.Inlines.Add(new Run()
                     {
                         Text = trimmedError + "\n",
-                        Background = trimmedError.Contains("error")? Brushes.DarkRed : Brushes.Goldenrod,
+                        Background = trimmedError.Contains("error") ? Brushes.DarkRed : Brushes.Goldenrod,
                     });
                 }
                 ExecuteButton.IsEnabled = false;

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -53,7 +53,8 @@ namespace C_Flat
             CreateExecuteAnimation();
 
             ExecuteButton.IsEnabled = false;
-
+            
+            //  Button component setup
             _showTree = new Button()
             {
                 Content = "Show parse tree",
@@ -86,10 +87,13 @@ namespace C_Flat
                 Background = new SolidColorBrush(Color.FromRgb(106, 27, 154)),
             };
             _showCode.Click += ShowCode_Click;
-
+            
+            //  Initial buttons
             LeftButton.Content = _showTree;
             RightButton.Content = _showOutput;
 
+            
+            // Create component for viewing code output
             _codeView = new TextBlock()
             {
                 Background = Brushes.Transparent,
@@ -98,14 +102,19 @@ namespace C_Flat
                 TextWrapping = TextWrapping.NoWrap,
                 IsEnabled = false,
             };
+            //  Initialize output window to show code output
             OutputBorder.Child = _codeView;
             ExpandAll.Visibility = Visibility.Hidden;
+            
+            //  Setup handling for line numbers
             SourceInput.TextChanged += UpdateLineNumbers;
             LineNumbers.FontSize = SourceInput.FontSize;
         }
 
         private void UpdateLineNumbers(object sender, TextChangedEventArgs e)
         {
+            
+            //  Recreate line numbers if source line count changes
             if (LineNumbers.Inlines.Count != SourceInput.LineCount)
             {
                 LineNumbers.Inlines.Clear();
@@ -118,112 +127,56 @@ namespace C_Flat
         }
         private void ButtonTranspile_Click(object sender, RoutedEventArgs e)
         {
+            //  Set code view text to blank and reset border thickness
             _codeView.Text = "";
             SourceInput.BorderThickness = new Thickness(0);
             OutputBorder.BorderThickness = new Thickness(0);
+            
+            //  Disable execute button whilst transpiling
             ExecuteButton.IsEnabled = false;
+            
+            //  Null all relevant variables
             _executionOutput = null;
             _parseTree = null;
+            
+            //TODO: Consider moving this to after a successful transpile
+            //  Mark new changes to the transpiled program.
             _unsavedChanges = true;
+            
+            //  Clear lexer logs before lexing input
             _lexer.ClearLogs();
             if (_lexer.Tokenise(SourceInput.Text) != 0)
             {
-                //Lexer Failed!
-                _codeView.Inlines.Clear();
-                var run = new Run
-                {
-                    Text = "Lexing Failed! Printing logs: \n",
-                    Background = Brushes.DarkRed,
-                    Foreground = Brushes.White
-                };
-                _codeView.Inlines.Add(run);
-                foreach (var errorMessage in _parser.GetInMemoryLogs()
-                             .Where(log => log.Level > LogEventLevel.Information))
-                {
-                    run.Background = errorMessage.Level switch
-                    {
-                        LogEventLevel.Warning => new SolidColorBrush(Colors.Goldenrod),
-                        _ => Brushes.DarkRed
-                    };
-                    run.Text = errorMessage.RenderMessage();
-                    _codeView.Inlines.Add(run);
-                }
-                SourceInput.BorderBrush = new SolidColorBrush(Colors.DarkRed);
-                SourceInput.BorderThickness = new Thickness(2);
-                _showTree.IsEnabled = false;
-                Snackbar.Appearance = ControlAppearance.Danger;
-                Snackbar.Show("Lexing Failed!");
-	            ShowCode_Click(default!, default!);
+                // Lexer failed!
+                FailTranspile("Lexing", _lexer.GetInMemoryLogs()
+                    .Where(log => log.Level > LogEventLevel.Information));
                 return;
             }
-
+            
             var tokens = _lexer.GetTokens();
+            
             _parser.ClearLogs();
             
             if (_parser.Parse(tokens) != 0)
             {
-                //Parser failed!
-                _codeView.Inlines.Clear();
-                var run = new Run
-                {
-                    Text = "Parsing Failed! Printing logs: \n",
-                    Background = Brushes.DarkRed,
-                    Foreground = Brushes.White
-                };
-                _codeView.Inlines.Add(run);
-                foreach (var errorMessage in _parser.GetInMemoryLogs()
-                             .Where(log => log.Level > LogEventLevel.Information))
-                {
-                    run.Background = errorMessage.Level switch
-                    {
-                        LogEventLevel.Warning => new SolidColorBrush(Colors.Goldenrod),
-                        _ => Brushes.DarkRed
-                    };
-                    run.Text = errorMessage.RenderMessage() + "\n";
-                    _codeView.Inlines.Add(run);
-                }
-                
-                SourceInput.BorderBrush = new SolidColorBrush(Colors.DarkRed);
-                SourceInput.BorderThickness = new Thickness(2);
-                _showTree.IsEnabled = false;
-                Snackbar.Appearance = ControlAppearance.Danger;
-                Snackbar.Show("Parsing Failed!");
-	            ShowCode_Click(default!, default!);
+                //  Parser failed!
+                FailTranspile("Parsing", _parser.GetInMemoryLogs()
+                    .Where(log => log.Level > LogEventLevel.Information));
                 return;
             }
-
+            
+            //Construct parse tree element
             var parseNodes = _parser.GetParseTree();
-            //Construct parse tree element passing parse tree
             ConstructParseTree(parseNodes);
-            //TODO - move error printing into helper method
+            
             if (_transpiler.Transpile(parseNodes) != 0)
             {
-                //Transpiler failed!
-                _codeView.Inlines.Clear();
-                _codeView.Inlines.Add(new Run
-                {
-                    Text = "Transpilation Failed! Printing logs: \n",
-                    Background = Brushes.DarkRed,
-                    Foreground = Brushes.White
-                });
-                foreach (var errorMessage in _transpiler.GetInMemoryLogs()
-                             .Where(log => log.Level > LogEventLevel.Information))
-                {
-                    _codeView.Inlines.Add(new Run
-                    {
-                        Background = errorMessage.Level switch
-                        {
-                            LogEventLevel.Warning => new SolidColorBrush(Colors.Goldenrod),
-                            _ => Brushes.DarkRed
-                        },
-                        Text = errorMessage.RenderMessage() + "\n"
-                    });
-                }
-                SourceInput.BorderBrush = new SolidColorBrush(Colors.DarkRed);
-                SourceInput.BorderThickness = new Thickness(2);
-	            ShowCode_Click(default!, default!);
+                //  Transpilation failed!
+                FailTranspile("Transpilation", _transpiler.GetInMemoryLogs()
+                    .Where(log => log.Level > LogEventLevel.Information));
                 return;
             }
+            
             var transpiledProgram = _transpiler.Program;
             Snackbar.Appearance = ControlAppearance.Success;
             Snackbar.Show("Transpile Successful!");
@@ -234,8 +187,51 @@ namespace C_Flat
             ShowCode_Click(default!, default!);
         }
 
+        private void FailTranspile(string stage, IEnumerable<LogEvent> logs)
+        {
+            //  Transpile failed!
+            // Clear output text and print logs
+            _codeView.Inlines.Clear();
+            _codeView.Inlines.Add(new Run()
+            {
+                Text = $"{stage} Failed! Printing logs: \n",
+                FontWeight = FontWeights.Bold,
+                TextDecorations = TextDecorations.Underline,
+                FontSize = 24,
+                Background = Brushes.Transparent,
+                Foreground = Brushes.White,
+            });
+            foreach (var errorMessage in logs)
+            {
+                _codeView.Inlines.Add(new Run()
+                {
+                    Text = $"{errorMessage.RenderMessage()} \n",
+                    Background =  errorMessage.Level switch
+                    {
+                        LogEventLevel.Warning => new SolidColorBrush(Colors.Goldenrod),
+                        _ => Brushes.DarkRed
+                    },
+                });
+            }
+                
+            //  Set input border to red to indicate failure
+            SourceInput.BorderBrush = new SolidColorBrush(Colors.DarkRed);
+            SourceInput.BorderThickness = new Thickness(2);
+                
+            //  Disable parse tree view
+            _showTree.IsEnabled = false;
+            //  Show a message indicating failed lexing
+            Snackbar.Appearance = ControlAppearance.Danger;
+            Snackbar.Show($"{stage} Failed!");
+                
+            //  Show code view
+            ShowCode_Click(default!, default!);
+            SaveOutput.Visibility = Visibility.Hidden;
+        }
+
         private async void ButtonExecuteCode_Click(object sender, RoutedEventArgs e)
         {
+            //  Disable buttons
             TranspileButton.IsEnabled = false;
             ExecuteButton.IsEnabled = false;
             _executionOutput = new TextBlock
@@ -304,7 +300,7 @@ namespace C_Flat
                 Snackbar.Show("Execution Failed!");
                 return;
             }
-            //Otherwise just copy output directly to text-box and apply a green "success border"
+            //  Otherwise just copy output directly to text-box and apply a green "success border"
             _executionOutput.Text = output;
             OutputBorder.BorderBrush = Brushes.LawnGreen;
             OutputBorder.BorderThickness = new Thickness(2);

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -138,11 +138,7 @@ namespace C_Flat
             //  Null all relevant variables
             _executionOutput = null;
             _parseTree = null;
-            
-            //TODO: Consider moving this to after a successful transpile
-            //  Mark new changes to the transpiled program.
-            _unsavedChanges = true;
-            
+
             //  Clear lexer logs before lexing input
             _lexer.ClearLogs();
             if (_lexer.Tokenise(SourceInput.Text) != 0)
@@ -176,6 +172,9 @@ namespace C_Flat
                     .Where(log => log.Level > LogEventLevel.Information));
                 return;
             }
+            
+            //  Mark new changes to the transpiled program.
+            _unsavedChanges = true;
             
             var transpiledProgram = _transpiler.Program;
             Snackbar.Appearance = ControlAppearance.Success;

--- a/C_Flat_Interpreter/Common/Exceptions/Exceptions.cs
+++ b/C_Flat_Interpreter/Common/Exceptions/Exceptions.cs
@@ -1,0 +1,10 @@
+﻿namespace C_Flat_Interpreter.Common.Exceptions;
+
+public class InvalidSyntaxException : Exception
+{
+    public InvalidSyntaxException(string? message) : base($"Invalid Syntax encountered! {message}") { }
+}
+public class SyntaxErrorException : Exception
+{
+    public SyntaxErrorException(string? message) : base($"Syntax Error encountered! {message}") { }
+}

--- a/C_Flat_Interpreter/Common/Exceptions/Exceptions.cs
+++ b/C_Flat_Interpreter/Common/Exceptions/Exceptions.cs
@@ -1,10 +1,20 @@
 ﻿namespace C_Flat_Interpreter.Common.Exceptions;
 
-public class InvalidSyntaxException : Exception
+public class ParserException : Exception
 {
-    public InvalidSyntaxException(string? message) : base($"Invalid Syntax encountered! {message}") { }
+    protected ParserException(string prefix, string? message) : base($"{prefix} {message}") { }
+    protected ParserException(string prefix, int line, string? message) : base($"[Line: {line}] {prefix} {message}") { }
+
 }
-public class SyntaxErrorException : Exception
+
+public class InvalidSyntaxException : ParserException
 {
-    public SyntaxErrorException(string? message) : base($"Syntax Error encountered! {message}") { }
+    public InvalidSyntaxException(string? message) : base("Invalid Syntax!", message) { }
+    public InvalidSyntaxException(string? message, int line) : base("Invalid Syntax!", line, message) { }
+
+}
+public class SyntaxErrorException : ParserException
+{
+    public SyntaxErrorException(string? message) : base("Syntax Error!", message) { }
+    public SyntaxErrorException(string? message, int line) : base("Syntax Error!", line, message) { }
 }

--- a/C_Flat_Interpreter/Common/Token.cs
+++ b/C_Flat_Interpreter/Common/Token.cs
@@ -13,4 +13,9 @@ public class Token
         Word = word;
         Line = line;
     }
+
+    public override string ToString()
+    {
+        return Word.Trim();
+    }
 }

--- a/C_Flat_Interpreter/Common/VariableTable.cs
+++ b/C_Flat_Interpreter/Common/VariableTable.cs
@@ -26,13 +26,13 @@ public class VariableTable
         return _table.ContainsKey(identifier);
     }
 
-    public ParseNode GetType(string identifier)
+    public NodeType GetType(string identifier)
     {
         while (true)
         {
             var node = _table[identifier];
 
-            if (node.type != NodeType.VarIdentifier) return node;
+            if (node.type != NodeType.VarIdentifier) return node.type;
             identifier = node.token?.Word ?? throw new Exception("Identifier node token is null");
         }
     }

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -159,7 +159,7 @@ public class Parser : InterpreterLogger
 		}
 		catch (InvalidSyntaxException e)
 		{
-			_logger.Warning(e.Message);
+			_logger.Debug(e.Message);
 			Reset(currentIndex);
 		}
 		
@@ -171,7 +171,7 @@ public class Parser : InterpreterLogger
 		}
 		catch (InvalidSyntaxException e)
 		{
-			_logger.Warning(e.Message);
+			_logger.Debug(e.Message);
 			Reset(currentIndex);
 		}
 		
@@ -183,7 +183,7 @@ public class Parser : InterpreterLogger
 		}
 		catch (InvalidSyntaxException e)
 		{
-			_logger.Warning(e.Message);
+			_logger.Debug(e.Message);
 			Reset(currentIndex);
 		}
 		try
@@ -194,7 +194,7 @@ public class Parser : InterpreterLogger
 		}
 		catch (InvalidSyntaxException e)
 		{
-			_logger.Warning(e.Message);
+			_logger.Debug(e.Message);
 			Reset(currentIndex);
 		}
 		throw new SyntaxErrorException("Unable to parse statement!");

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -111,6 +111,7 @@ public class Parser : InterpreterLogger
     {
 	    ParseNode newNode = new ParseNode(type);
 	    func(newNode);
+	    _logger.Information($"Successfully parsed {newNode.type}!");
 	    return newNode;
     }
 

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -193,18 +193,20 @@ public class Parser : InterpreterLogger
 
 			if (_variableTable.Exists(identifier))
 			{
-				ParseNode childNode = CreateNode(NodeType.VarAssignment, VarAssignment);
+				var childNode = CreateNode(NodeType.VarAssignment, VarAssignment);
 				node.AddChild(childNode);
-
-				ParseNode valueNode = childNode.getChildren()[2]; //gets the value the variable is assigned to
-				if (_variableTable.GetType(identifier).type != NodeType.Null && _variableTable.GetType(identifier) != valueNode)
+				
+				//	gets the value the variable is assigned to
+				var assignmentValue = childNode.getChildren()[2];
+				var existingType = _variableTable.GetType(identifier);
+				if (existingType != NodeType.Null && existingType != assignmentValue.type)
 				{
-					_logger.Error("Syntax Error! variable is not of type: {@type} ", valueNode);
+					throw new SyntaxErrorException($"Invalid variable assignment! Type '{assignmentValue.type}' cannot be assigned to '{identifier}' of type '{existingType}'", _currentLine);
 				}
 				currentIndex = _currentIndex;
 				return;
 			}
-			_logger.Error("Syntax Error! variable is not declared: {@word} ", _tokens[_currentIndex].Word);
+			throw new SyntaxErrorException($"Invalid variable assignment! Variable '{_tokens.ElementAtOrDefault(_currentIndex)}' has not been declared!", _currentLine);
 		}
 		catch (InvalidSyntaxException e)
 		{
@@ -232,10 +234,10 @@ public class Parser : InterpreterLogger
 		var identifier = _tokens[_currentIndex].Word.Trim();
 		int Rein = _currentIndex;
 		
+		//	Throw syntax error if variable already exists
 		if (_variableTable.Exists(identifier))
 		{
-			_logger.Error("Syntax Error! variable has already been declared: {@word} ", _tokens[_currentIndex].Word);
-			throw new SyntaxErrorException();
+			throw new SyntaxErrorException($"Variable '{_tokens.ElementAtOrDefault(_currentIndex)}' has already been declared!", _currentLine);
 		}
 		
 		// check if a value is being assigned


### PR DESCRIPTION
## Description:
This PR completely overhauls logging within the parser. It also adds much more robust exception handling which provides helpful user feedback when they make syntax errors.
There are two new exception types, `InvalidSyntaxException` and `SyntaxErrorException`. At first glance these might seem the same however they are used for different purposes. 

`InvalidSyntaxException` is used when the parser encounters syntax which is invalid however not necessarily an error. For example when parsing the following statement, `var i;`, the parser will attempt to parse a variable assignment however when it notices the lack of an assignment operator `=` it will throw an invalid syntax exception.  This is because whilst it is not valid syntax for a variable assignment, the previous two tokens `var i` are valid syntax and do not contain any errors, therefore it is not necessarily a syntax error.

Conversely `SyntaxErrorException` is used when syntactical errors are encountered, such as `var i = 20`, the semicolon is missing which is a syntax error and thus we should stop parsing and inform the user of the error.

In short, `InvalidSyntaxException` should be used when we are unable to parse the token but it's not a syntactical error, and `SyntaxErrorExceptions` should be thrown when we encounter an error which should cause parsing to fail.

I also added some small GUI fixes/changes to make errors more user-readable.