### PR TITLE
Allow for variables to store other types

### DIFF
--- a/C_Flat Definition.md
+++ b/C_Flat Definition.md
@@ -227,7 +227,9 @@ A loop can be created using the keyword `while`, followed by a logic statement w
 
 `<Word>::= 1*(a-zA-Z) - <Keywords>`
 
-`<Assignment>::= <Identifier> '=' (<Expression> | ' " '<Word>' " ' | <Logic-Statement> | <Identifier>) ‘;’`
+`<Assignment>::= <Identifier> '=' <Assignment-Value> ‘;’`
+
+`<Assignment-Value>::= (<Expression> | ' " ' <Word> ' " ' | <Boolean> | <Identifier>)`
 
 ### Functions:
 

--- a/C_Flat_GUI/MainWindow.xaml.cs
+++ b/C_Flat_GUI/MainWindow.xaml.cs
@@ -173,14 +173,24 @@ namespace C_Flat
                 return;
             }
             
+            if (_transpiler.GetInMemoryLogs().Any(log => log.Level > LogEventLevel.Information))
+            {
+                Snackbar.Appearance = ControlAppearance.Caution;
+                Snackbar.Show("Caution!","Transpile succeeded but with warnings...", SymbolRegular.CheckboxWarning20);
+                SourceInput.BorderBrush = new SolidColorBrush(Colors.Goldenrod);
+                SourceInput.BorderThickness = new Thickness(2);
+            }
+            else
+            {
+                Snackbar.Appearance = ControlAppearance.Success;
+                Snackbar.Show("Success!", "Transpile was successful!", SymbolRegular.CheckboxChecked20);
+                SourceInput.BorderBrush = new SolidColorBrush(Colors.LawnGreen);
+                SourceInput.BorderThickness = new Thickness(2);
+            }
             //  Mark new changes to the transpiled program.
             _unsavedChanges = true;
             
             var transpiledProgram = _transpiler.Program;
-            Snackbar.Appearance = ControlAppearance.Success;
-            Snackbar.Show("Transpile Successful!");
-            SourceInput.BorderBrush = new SolidColorBrush(Colors.LawnGreen);
-            SourceInput.BorderThickness = new Thickness(2);
             ExecuteButton.IsEnabled = true;
             _codeView.Text = $"{transpiledProgram}";
             ShowCode_Click(default!, default!);
@@ -221,7 +231,7 @@ namespace C_Flat
             _showTree.IsEnabled = false;
             //  Show a message indicating failed lexing
             Snackbar.Appearance = ControlAppearance.Danger;
-            Snackbar.Show($"{stage} Failed!");
+            Snackbar.Show("Fail!", $"Transpile failed at {stage.ToLower()} stage!", SymbolRegular.ErrorCircle20);
                 
             //  Show code view
             ShowCode_Click(default!, default!);

--- a/C_Flat_Interpreter/C_Flat_Interpreter.csproj
+++ b/C_Flat_Interpreter/C_Flat_Interpreter.csproj
@@ -12,8 +12,4 @@
       <PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Execution" />
-    </ItemGroup>
-
 </Project>

--- a/C_Flat_Interpreter/Common/Enums/NodeType.cs
+++ b/C_Flat_Interpreter/Common/Enums/NodeType.cs
@@ -17,5 +17,7 @@ public enum NodeType //will be added to
     WhileStatement,
     VarIdentifier,
     VarAssignment,
-    DeclareVariable
+    AssignmentValue,
+    DeclareVariable,
+    String,
 }

--- a/C_Flat_Interpreter/Common/Enums/TokenType.cs
+++ b/C_Flat_Interpreter/Common/Enums/TokenType.cs
@@ -13,7 +13,7 @@ public enum TokenType //will be added to later, names not final
     SemiColon,
     Num,
     Divide,
-    String,
+    Word,
     Sub,
     Not,
     And,
@@ -22,5 +22,6 @@ public enum TokenType //will be added to later, names not final
     Less,
     More,
     NotEqual,
-    Assignment
+    Assignment,
+    String
 }

--- a/C_Flat_Interpreter/Common/Exceptions/Exceptions.cs
+++ b/C_Flat_Interpreter/Common/Exceptions/Exceptions.cs
@@ -18,3 +18,10 @@ public class SyntaxErrorException : ParserException
     public SyntaxErrorException(string? message) : base("Syntax Error!", message) { }
     public SyntaxErrorException(string? message, int line) : base("Syntax Error!", line, message) { }
 }
+public class IncorrectTypeException : ParserException
+{
+    public IncorrectTypeException(string? message) : base("Incorrect Type!", message) { }
+
+    public IncorrectTypeException(string? message, int line) : base("Incorrect Type!", line, message) { }
+
+}

--- a/C_Flat_Interpreter/Common/VariableTable.cs
+++ b/C_Flat_Interpreter/Common/VariableTable.cs
@@ -3,15 +3,11 @@ using C_Flat_Interpreter.Common.Enums;
 
 namespace C_Flat_Interpreter.Common;
 
-public class VariableTable
+public static class VariableTable
 {
-    private Dictionary<string, ParseNode> _table;
-    public VariableTable()
-    {
-        _table = new Dictionary<string, ParseNode>();
-    }
+    private static Dictionary<string, ParseNode> _table = new();
 
-    public void Add(string word, ParseNode node)
+    public static void Add(string word, ParseNode node)
     {
         if (_table.ContainsKey(word))
             _table[word] = node;
@@ -19,7 +15,7 @@ public class VariableTable
             _table.Add(word, node);
     }
     
-    public void Add(string word)
+    public static void Add(string word)
     {
         if (_table.ContainsKey(word))
             _table[word] = new(NodeType.Null);
@@ -27,12 +23,12 @@ public class VariableTable
             _table.Add(word, new(NodeType.Null));
     }
 
-    public bool Exists(string identifier)
+    public static bool Exists(string identifier)
     {
         return _table.ContainsKey(identifier);
     }
 
-    public NodeType GetType(string identifier)
+    public static NodeType GetType(string identifier)
     {
         while (true)
         {
@@ -41,5 +37,10 @@ public class VariableTable
             if (node.type != NodeType.VarIdentifier) return node.type;
             identifier = node.token?.Word ?? throw new Exception("Identifier node token is null");
         }
+    }
+
+    public static void Clear()
+    {
+        _table.Clear();
     }
 }

--- a/C_Flat_Interpreter/Common/VariableTable.cs
+++ b/C_Flat_Interpreter/Common/VariableTable.cs
@@ -13,12 +13,18 @@ public class VariableTable
 
     public void Add(string word, ParseNode node)
     {
-        _table.Add(word, node);
+        if (_table.ContainsKey(word))
+            _table[word] = node;
+        else
+            _table.Add(word, node);
     }
     
     public void Add(string word)
     {
-        _table.Add(word, new ParseNode(NodeType.Null));
+        if (_table.ContainsKey(word))
+            _table[word] = new(NodeType.Null);
+        else
+            _table.Add(word, new(NodeType.Null));
     }
 
     public bool Exists(string identifier)

--- a/C_Flat_Interpreter/Common/VariableTable.cs
+++ b/C_Flat_Interpreter/Common/VariableTable.cs
@@ -26,13 +26,13 @@ public class VariableTable
         return _table.ContainsKey(identifier);
     }
 
-    public ParseNode GetType(string identifier)
+    public NodeType GetType(string identifier)
     {
         while (true)
         {
             var node = _table[identifier];
 
-            if (node.type != NodeType.VarIdentifier) return node;
+            if (node.type != NodeType.VarIdentifier) return node.type;
             identifier = node.token?.Word ?? throw new Exception("Identifier node token is null");
         }
     }

--- a/C_Flat_Interpreter/Lexer/Lexer.cs
+++ b/C_Flat_Interpreter/Lexer/Lexer.cs
@@ -139,6 +139,14 @@ public class Lexer : InterpreterLogger
                         newToken.Type = TokenType.More;
                         newToken.Word = whitespace + c;
                         break;
+                    case '"':
+                        newToken.Type = TokenType.String;
+                        newToken.Word = whitespace + c;
+                        i++;
+                        var letters2 = ParseString(j, i);
+                        newToken.Word += letters2;
+                        i += letters2.Length - 1;
+                        break;
                     default:
                         if (char.IsDigit(c))
                         {
@@ -149,8 +157,8 @@ public class Lexer : InterpreterLogger
                         }
                         else if (char.IsLetter(c))
                         {
-                            newToken.Type = TokenType.String;
-                            var letters = ParseString(j, i);
+                            newToken.Type = TokenType.Word;
+                            var letters = ParseWord(j, i);
                             newToken.Word = whitespace + letters;
                             i += letters.Length - 1;
                         }
@@ -195,7 +203,7 @@ public class Lexer : InterpreterLogger
         }
         return numberString;
     }
-    private string ParseString(int line, int index)
+    private string ParseWord(int line, int index)
     {
         var wordString = _lines[line][index].ToString();
         while (index+1 < _lines[line].Length)
@@ -206,6 +214,25 @@ public class Lexer : InterpreterLogger
             }
             else
             {
+                break;
+            }
+        }
+        return wordString.ToLower();
+    }
+
+
+    private string ParseString(int line, int index)
+    {
+        var wordString = _lines[line][index].ToString();
+        while (index + 1 < _lines[line].Length)
+        {
+            if ((_lines[line][index + 1]) != '"')
+            {
+                wordString += _lines[line][++index];
+            }
+            else
+            {
+                wordString += _lines[line][++index];
                 break;
             }
         }

--- a/C_Flat_Interpreter/Lexer/Lexer.cs
+++ b/C_Flat_Interpreter/Lexer/Lexer.cs
@@ -142,10 +142,18 @@ public class Lexer : InterpreterLogger
                     case '"':
                         newToken.Type = TokenType.String;
                         newToken.Word = whitespace + c;
-                        i++;
-                        var letters2 = ParseString(j, i);
-                        newToken.Word += letters2;
-                        i += letters2.Length - 1;
+                        var substring = ParseString(j, ++i);
+                        newToken.Word += substring;
+                        i += substring.Length - 1;
+                        if (_lines[j].ElementAtOrDefault(i+1) != '"')
+                        {
+                            _logger.Error("Invalid lexeme encountered! Disregarding: {invalidToken}", newToken);
+                            newToken = null;
+                            _failed = true;
+                        }
+                        else
+                            newToken.Word += _lines[j][++i];
+                        
                         break;
                     default:
                         if (char.IsDigit(c))
@@ -158,9 +166,9 @@ public class Lexer : InterpreterLogger
                         else if (char.IsLetter(c))
                         {
                             newToken.Type = TokenType.Word;
-                            var letters = ParseWord(j, i);
-                            newToken.Word = whitespace + letters;
-                            i += letters.Length - 1;
+                            substring = ParseWord(j, i);
+                            newToken.Word = whitespace + substring;
+                            i += substring.Length - 1;
                         }
                         else
                         {
@@ -226,13 +234,12 @@ public class Lexer : InterpreterLogger
         var wordString = _lines[line][index].ToString();
         while (index + 1 < _lines[line].Length)
         {
-            if ((_lines[line][index + 1]) != '"')
+            if (_lines[line][index + 1] != '"')
             {
                 wordString += _lines[line][++index];
             }
             else
             {
-                wordString += _lines[line][++index];
                 break;
             }
         }

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -221,7 +221,7 @@ public class Parser : InterpreterLogger
 	private void DeclareVariable(ParseNode node)
 	{
 		// check for String token with the name "var"
-		if (Match(TokenType.String) && CheckVarLiteral())
+		if (Match(TokenType.Word) && CheckVarLiteral())
 		{
 			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
 			Advance();
@@ -273,14 +273,14 @@ public class Parser : InterpreterLogger
 	//TODO - Rename to match ebnf (Identifier)
 	private void VarIdentifier(ParseNode node)
 	{
-		if (Match(TokenType.String))
+		if (Match(TokenType.Word))
 		{
 			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
 			Advance();
 		}
 		else
 		{
-			throw new SyntaxErrorException($"Invalid variable identifier! Expected token type 'string'. Actual: '{_tokenType}'", _currentLine);
+			throw new InvalidSyntaxException($"Invalid variable identifier! Expected token type word. Actual: '{_tokenType}'", _currentLine);
 		}
 	}
 	//TODO - Rename to match ebnf (Assignment)
@@ -335,6 +335,34 @@ public class Parser : InterpreterLogger
 			Reset(Rein);
 			_logger.Warning(e2.Message);
 		}
+        try
+        {
+			if (Match(TokenType.String))
+			{
+				node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
+				Advance();
+			}
+            else
+            {
+				throw new InvalidSyntaxException($"invalid assignment, expected 'String'. Actual: '{_tokens.ElementAtOrDefault(_currentIndex)}'", _currentLine);
+			}
+			if (Match(TokenType.SemiColon))
+			{
+				node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
+				Advance();
+				return;
+			}
+			else
+			{
+				throw new InvalidSyntaxException($"Unterminated assignment, expected ';'. Actual: '{_tokens.ElementAtOrDefault(_currentIndex)}'", _currentLine);
+			}
+		}
+		catch (InvalidSyntaxException e2)
+		{
+			Reset(Rein);
+			_logger.Warning(e2.Message);
+		}
+
 		try
 		{
 			node.AddChild(CreateNode(NodeType.VarIdentifier, VarIdentifier));
@@ -356,10 +384,16 @@ public class Parser : InterpreterLogger
 			throw new SyntaxErrorException($"Unterminated assignment, expected ';'. Actual: '{_tokens.ElementAtOrDefault(_currentIndex)}'", _currentLine);
 		}
 	}
-	#endregion
-	
-	#region Expressions
-	private void Expression(ParseNode node)
+    #endregion
+
+    #region Strings
+
+
+
+    #endregion
+
+    #region Expressions
+    private void Expression(ParseNode node)
 	{
 		//	Try add first term node
 		node.AddChild(CreateNode(NodeType.Term, Term));
@@ -395,7 +429,7 @@ public class Parser : InterpreterLogger
 			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
 			Advance();
 		}
-		else if (Match(TokenType.String))
+		else if (Match(TokenType.Word))
 		{
 			node.AddChild(CreateNode(NodeType.VarIdentifier, VarIdentifier));
 		}
@@ -466,7 +500,7 @@ public class Parser : InterpreterLogger
 			}
 		}
 		//	Otherwise check for a boolean literal
-		else if (Match(TokenType.String) && CheckBoolLiteral())
+		else if (Match(TokenType.Word) && CheckBoolLiteral())
 		{
 			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
 			Advance();
@@ -565,7 +599,7 @@ public class Parser : InterpreterLogger
     //TODO - Rename to match EBNF
 	private void IfStatements(ParseNode node)
     {
-	    if (Match(TokenType.String) && CheckIf())
+	    if (Match(TokenType.Word) && CheckIf())
 		{
 			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
 			Advance();
@@ -615,7 +649,7 @@ public class Parser : InterpreterLogger
 			throw new SyntaxErrorException($"Invalid block within if statement!");
 		}
 		
-		if (Match(TokenType.String) && CheckElse())
+		if (Match(TokenType.Word) && CheckElse())
 		{
 			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
 			Advance();
@@ -635,7 +669,7 @@ public class Parser : InterpreterLogger
 
 	private void WhileStatement(ParseNode node)
 	{
-		if (Match(TokenType.String) && CheckWhile())
+		if (Match(TokenType.Word) && CheckWhile())
 		{
 			node.AddChild(new ParseNode(NodeType.Terminal, _tokens[_currentIndex]));
 			Advance();

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -34,7 +34,6 @@ public class Parser : InterpreterLogger
 	private int _totalTokens;
 	private List<Token> _tokens;
 	private List<ParseNode> _parseTree = new();
-	private VariableTable _variableTable = new();
 
 	private delegate void Delegate(ParseNode node);
 
@@ -126,7 +125,7 @@ public class Parser : InterpreterLogger
 		_tokens = tokens;
 		_totalTokens = tokens.Count;
 		_parseTree = new();
-		_variableTable = new();
+		VariableTable.Clear();
 		Reset();
 		//TODO - investigate better way to do this
 		try
@@ -191,7 +190,7 @@ public class Parser : InterpreterLogger
 		{
 			var identifier = _tokens[_currentIndex].Word.Trim();
 
-			if (_variableTable.Exists(identifier))
+			if (VariableTable.Exists(identifier))
 			{
 				node.AddChild( CreateNode(NodeType.VarAssignment, VarAssignment));
 				currentIndex = _currentIndex;
@@ -229,7 +228,7 @@ public class Parser : InterpreterLogger
 		int Rein = _currentIndex;
 		
 		//	Throw syntax error if variable already exists
-		if (_variableTable.Exists(identifier))
+		if (VariableTable.Exists(identifier))
 		{
 			throw new SyntaxErrorException($"Variable '{_tokens.ElementAtOrDefault(_currentIndex)}' has already been declared!", _currentLine);
 		}
@@ -249,7 +248,7 @@ public class Parser : InterpreterLogger
 
 		node.AddChild(CreateNode(NodeType.VarIdentifier, VarIdentifier));
 		
-		_variableTable.Add(identifier);
+		VariableTable.Add(identifier);
 
 		if (Match(TokenType.SemiColon))
 		{
@@ -295,15 +294,15 @@ public class Parser : InterpreterLogger
 			var identifier = identifierNode.getChildren().First().token?.ToString();
 			var valueNode = CreateNode(NodeType.AssignmentValue, AssignmentValue);
 			var assignmentValue = valueNode.getChildren().First();
-			if (_variableTable.Exists(identifier ?? throw new Exception("Invalid identifier token")))
+			if (VariableTable.Exists(identifier ?? throw new Exception("Invalid identifier token")))
 			{
-				var existingType = _variableTable.GetType(identifier);
+				var existingType = VariableTable.GetType(identifier);
 				if (existingType != NodeType.Null && existingType != assignmentValue.type)
 				{
 					throw new SyntaxErrorException($"Invalid variable assignment! Type '{assignmentValue.type}' cannot be assigned to '{identifier}' of type '{existingType}'", _currentLine);
 				}
 			}
-			_variableTable.Add(identifier,assignmentValue);
+			VariableTable.Add(identifier,assignmentValue);
 			//	Only add if the assignment is valid
 			node.AddChild(valueNode);
 		}
@@ -452,7 +451,7 @@ public class Parser : InterpreterLogger
 			//	Check whether the value node is of the same type
 			var identifier = identifierNode.getChildren().First().token?.ToString();
 			// Check whether type is correct
-			if(_variableTable.GetType(identifier?? throw new SyntaxErrorException("Invalid identifier token")) is not NodeType.Expression)
+			if(VariableTable.GetType(identifier?? throw new SyntaxErrorException("Invalid identifier token")) is not NodeType.Expression)
 				throw new IncorrectTypeException($"Variable {identifier} is not of type 'Expression'");
 			node.AddChild(identifierNode);
 		}
@@ -553,7 +552,7 @@ public class Parser : InterpreterLogger
 				var identifierNode = CreateNode(NodeType.VarIdentifier, VarIdentifier);
 				var identifier = identifierNode.getChildren().First().token?.ToString();
 				// Check whether type is correct
-				if(_variableTable.GetType(identifier ?? throw new SyntaxErrorException("Invalid identifier token")) is not NodeType.Boolean)
+				if(VariableTable.GetType(identifier ?? throw new SyntaxErrorException("Invalid identifier token")) is not NodeType.Boolean)
 					throw new IncorrectTypeException($"Variable {identifier} is not of type 'Boolean'", _currentLine);
 				node.AddChild(identifierNode);
 				return;

--- a/C_Flat_Interpreter/Parser/Parser.cs
+++ b/C_Flat_Interpreter/Parser/Parser.cs
@@ -193,18 +193,20 @@ public class Parser : InterpreterLogger
 
 			if (_variableTable.Exists(identifier))
 			{
-				ParseNode childNode = CreateNode(NodeType.VarAssignment, VarAssignment);
+				var childNode = CreateNode(NodeType.VarAssignment, VarAssignment);
 				node.AddChild(childNode);
-
-				ParseNode valueNode = childNode.getChildren()[2]; //gets the value the variable is assigned to
-				if (_variableTable.GetType(identifier).type != NodeType.Null && _variableTable.GetType(identifier) != valueNode)
+				
+				//	gets the value the variable is assigned to
+				var assignmentValue = childNode.getChildren()[2];
+				var existingType = _variableTable.GetType(identifier);
+				if (existingType != NodeType.Null && existingType != assignmentValue.type)
 				{
-					_logger.Error("Syntax Error! variable is not of type: {@type} ", valueNode);
+					throw new SyntaxErrorException($"Invalid variable assignment! Type '{assignmentValue.type}' cannot be assigned to '{identifier}' of type '{existingType}'", _currentLine);
 				}
 				currentIndex = _currentIndex;
 				return;
 			}
-			_logger.Error("Syntax Error! variable is not declared: {@word} ", _tokens[_currentIndex].Word);
+			throw new SyntaxErrorException($"Invalid variable assignment! Variable '{_tokens.ElementAtOrDefault(_currentIndex)}' has not been declared!", _currentLine);
 		}
 		catch (InvalidSyntaxException e)
 		{
@@ -232,10 +234,10 @@ public class Parser : InterpreterLogger
 		var identifier = _tokens[_currentIndex].Word.Trim();
 		int Rein = _currentIndex;
 		
+		//	Throw syntax error if variable already exists
 		if (_variableTable.Exists(identifier))
 		{
-			_logger.Error("Syntax Error! variable has already been declared: {@word} ", _tokens[_currentIndex].Word);
-			throw new SyntaxErrorException();
+			throw new SyntaxErrorException($"Variable '{_tokens.ElementAtOrDefault(_currentIndex)}' has already been declared!", _currentLine);
 		}
 		
 		// check if a value is being assigned

--- a/C_Flat_Interpreter/Transpiler/Transpiler.cs
+++ b/C_Flat_Interpreter/Transpiler/Transpiler.cs
@@ -40,6 +40,7 @@ public class Transpiler : InterpreterLogger
         //Retrieve program.cs file
         Program = string.Empty;
         _currentLine = 0;
+        ClearLogs();
         var writer = File.CreateText(GetProgramPath());
         foreach (var node in parseTree)
         {

--- a/C_Flat_Tests/Tests_Unit/TranspilerUnit.cs
+++ b/C_Flat_Tests/Tests_Unit/TranspilerUnit.cs
@@ -31,12 +31,20 @@ public class TranspilerUnit : TestLogger
         
         declaration.AddChild(new (NodeType.Terminal, new Token(TokenType.Word){Word = "var"}));
         
+        var assignment = new ParseNode(NodeType.VarAssignment);
         var identifier = new ParseNode(NodeType.VarIdentifier);
         identifier.AddChild(new(NodeType.Terminal, new Token(TokenType.Word) {Word = " test"}));
-        declaration.AddChild(identifier);
+        assignment.AddChild(identifier);
         
-        declaration.AddChild(new (NodeType.Terminal, new Token(TokenType.SemiColon){Word = ";"}));
+        assignment.AddChild(new (NodeType.Terminal, new Token(TokenType.Assignment){Word = "="}));
         
+        var value = new ParseNode(NodeType.AssignmentValue);
+        var valueString = new ParseNode(NodeType.String);
+        valueString.AddChild(new(NodeType.Terminal, new Token(TokenType.String) {Word = "\"test\""}));
+        value.AddChild(valueString);
+        assignment.AddChild(value);
+        assignment.AddChild(new (NodeType.Terminal, new Token(TokenType.SemiColon){Word = ";"}));
+        declaration.AddChild(assignment);
         statement.AddChild(declaration);
         _parseTree.Add(statement);
         

--- a/C_Flat_Tests/Tests_Unit/TranspilerUnit.cs
+++ b/C_Flat_Tests/Tests_Unit/TranspilerUnit.cs
@@ -29,10 +29,10 @@ public class TranspilerUnit : TestLogger
         var statement = new ParseNode(NodeType.Statement);
         var declaration = new ParseNode(NodeType.DeclareVariable);
         
-        declaration.AddChild(new (NodeType.Terminal, new Token(TokenType.String){Word = "var"}));
+        declaration.AddChild(new (NodeType.Terminal, new Token(TokenType.Word){Word = "var"}));
         
         var identifier = new ParseNode(NodeType.VarIdentifier);
-        identifier.AddChild(new(NodeType.Terminal, new Token(TokenType.String) {Word = " test"}));
+        identifier.AddChild(new(NodeType.Terminal, new Token(TokenType.Word) {Word = " test"}));
         declaration.AddChild(identifier);
         
         declaration.AddChild(new (NodeType.Terminal, new Token(TokenType.SemiColon){Word = ";"}));


### PR DESCRIPTION
## Changes:
- Variables can now store strings and booleans
- Variables can also be assigned using other identifiers
- Transpiler now supports these new types
- BNF changes were made to simplify the variable assignment value parsing
- Transpiler now determines a static type for variables which do not have assignments at declaration.
- Pretty warning messages added ❇️ 

## Description:
This PR adds changes which allow variables to now store other types including, strings and boolean expressions. Variables can also be assigned to other variable identifiers. It also now adds transpile support for these new types. Further modification was made to allow for variables to be declared without assignment as this is not supported within C#. Instead the `VariableTable` is used to determine an appropriate type at the `Transpile` stage, based on the variables last assigned type. When variables are declared without ever being assigned a type, they are omitted from the transpiled code with a warning.

