### PR TITLE
Fix redeclaring out of scope variables

### DIFF
--- a/C_Flat_Interpreter/Common/VariableTable.cs
+++ b/C_Flat_Interpreter/Common/VariableTable.cs
@@ -11,7 +11,10 @@ public static class VariableTable
     {
         if (node == null)
         {
-            _table.Add(word, NodeType.Null);
+            if (_table.ContainsKey(word))
+                _table[word] = NodeType.Null;
+            else
+                _table.Add(word, NodeType.Null);
             return;
         }
         


### PR DESCRIPTION
Recent changes introduced a bug where if you were to try and redeclare a variable that is now out of scope the parser would fail.